### PR TITLE
Add functionality for adding and listing events from database

### DIFF
--- a/src/main/java/com/google/lecturechat/data/Event.java
+++ b/src/main/java/com/google/lecturechat/data/Event.java
@@ -1,0 +1,89 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.lecturechat.data;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.lecturechat.data.constants.EventEntity;
+import java.lang.IllegalArgumentException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A helper class for passing group data. */
+public final class Event {
+
+  private final long id;
+  private final String title;
+
+  // Format for time: YYYY-MM-DDTHH-MM-SS.
+  private final String start;
+  private final String end;
+
+  private final String creator;
+  private final List<Long> messages;
+  private final List<Long> attendees;
+
+  public Event(long id, String title, String start, String end, String creator, List<Long> messages, List<Long> attendees) {
+    this.id = id;
+    this.title = title;
+    this.start = start;
+    this.end = end;
+    this.creator = creator;
+    this.messages = messages;
+    this.attendees = attendees;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getStart() {
+    return start;
+  }
+
+  public String getEnd() {
+    return end;
+  }
+
+  public String getCreator() {
+    return creator;
+  }
+
+  public List<Long> getMessages() {
+    return messages;
+  }
+
+  public List<Long> getAttendees() {
+    return attendees;
+  }
+
+  public static Event createEventFromEntity(Entity eventEntity) {
+     if (eventEntity.getKind().equals(EventEntity.KIND.getLabel())) {
+      long id = eventEntity.getKey().getId();
+      String title = (String) (eventEntity.getProperty(EventEntity.TITLE_PROPERTY.getLabel()));
+      String start = (String) (eventEntity.getProperty(EventEntity.START_PROPERTY.getLabel()));
+      String end = (String) (eventEntity.getProperty(EventEntity.END_PROPERTY.getLabel()));
+      String creator = (String) (eventEntity.getProperty(EventEntity.CREATOR_PROPERTY.getLabel()));
+      List<Long> messages = (ArrayList) (eventEntity.getProperty(EventEntity.MESSAGES_PROPERTY.getLabel()));
+      List<Long> attendees = (ArrayList) (eventEntity.getProperty(EventEntity.ATTENDEES_PROPERTY.getLabel()));
+      return new Event(id, title, start, end, creator, messages, attendees);
+    } else {
+      throw new IllegalArgumentException("Attempted to create event object from entity that is not an event.");
+    }
+  }
+}

--- a/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
+++ b/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
@@ -19,7 +19,8 @@ public enum EventEntity {
   KIND("Event"),
   TITLE_PROPERTY("title"),
   START_PROPERTY("start"),
-  DURATION_PROPERTY("duration"),
+  END_PROPERTY("end"),
+  CREATOR_PROPERTY("creator"),
   MESSAGES_PROPERTY("messages"),
   ATTENDEES_PROPERTY("attendees");
 

--- a/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
+++ b/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
@@ -18,10 +18,10 @@ package com.google.lecturechat.data.constants;
 public enum EventEntity {
   KIND("Event"),
   TITLE_PROPERTY("title"),
-  START_PROPERTY("university"),
-  DURATION_PROPERTY("degree"),
-  MESSAGES_PROPERTY("year"),
-  ATTENDEES_PROPERTY("students"),
+  START_PROPERTY("start"),
+  DURATION_PROPERTY("duration"),
+  MESSAGES_PROPERTY("messages"),
+  ATTENDEES_PROPERTY("attendees");
 
   /* Labels comments and properties of events in the database. */
   private final String label;

--- a/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
+++ b/src/main/java/com/google/lecturechat/data/constants/EventEntity.java
@@ -14,19 +14,19 @@
 
 package com.google.lecturechat.data.constants;
 
-/** Specifies the kind and property names to use for group entities in the datastore database. */
-public enum GroupEntity {
-  KIND("Group"),
-  UNIVERSITY_PROPERTY("university"),
-  DEGREE_PROPERTY("degree"),
-  YEAR_PROPERTY("year"),
-  STUDENTS_PROPERTY("students"),
-  EVENTS_PROPERTY("events");
+/** Specifies the kind and property names to use for event entities in the datastore database. */
+public enum EventEntity {
+  KIND("Event"),
+  TITLE_PROPERTY("title"),
+  START_PROPERTY("university"),
+  DURATION_PROPERTY("degree"),
+  MESSAGES_PROPERTY("year"),
+  ATTENDEES_PROPERTY("students"),
 
-  /* Labels comments and properties of groups in the database. */
+  /* Labels comments and properties of events in the database. */
   private final String label;
 
-  private GroupEntity(String label) {
+  private EventEntity(String label) {
     this.label = label;
   }
 

--- a/src/main/java/com/google/lecturechat/servlets/EventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/EventsServlet.java
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.lecturechat.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import com.google.gson.Gson;
+import com.google.lecturechat.data.DatastoreAccess;
+import com.google.lecturechat.data.Event;
+
+/** Servlet for listing all events in a certain group. */
+@WebServlet("/events")
+public class EventsServlet extends HttpServlet {
+
+  private static final String ID_PARAMETER = "groupId";
+  private static DatastoreAccess datastore;
+
+  @Override
+  public void init() {
+    datastore = DatastoreAccess.getDatastoreAccess(); 
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    long groupId = Long.parseLong(request.getParameter(ID_PARAMETER));
+    List<Event> events = datastore.getAllEventsFromGroup(groupId);
+    response.setContentType("application/json;");
+    response.setCharacterEncoding("UTF-8");
+    Gson gson = new Gson();
+    response.getWriter().println(gson.toJson(events));
+  }
+}


### PR DESCRIPTION
Continues from pull request #2, `DatastoreAccess` now includes methods for 
- adding a new event to an existing group in the datastore
- listing all events in a group given the group ID.

Additionally, methods that modify or create entities now make use of atomic transactions to avoid problems when e.g someone tries to create groups with the same properties at the same time.

(Also has `EventEntity` and `Event` as helper classes + `EventsServlet` for conveniently testing new methods, but the main changes are in `DatastoreAccess`.)