### PR TITLE
Store dates as longs instead of strings

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -138,8 +138,8 @@ public class DatastoreAccess {
    *
    * @param groupId The id of the group the new event belongs to.
    * @param title The title of the new event.
-   * @param startTime The start time of the event (should be in UTC).
-   * @param endTime The end time of the event (should be in UTC).
+   * @param startTime The start time of the event (number of milliseconds since epoch time).
+   * @param endTime The end time of the event (number of milliseconds since epoch time).
    * @param creator The creator of the event.
    */
   public void addEventToGroup(

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -138,19 +138,19 @@ public class DatastoreAccess {
    *
    * @param groupId The id of the group the new event belongs to.
    * @param title The title of the new event.
-   * @param start The start time of the event (should be in UTC).
-   * @param end The end time of the event (should be in UTC).
+   * @param startTime The start time of the event (should be in UTC).
+   * @param endTime The end time of the event (should be in UTC).
    * @param creator The creator of the event.
    */
   public void addEventToGroup(
-      long groupId, String title, String startTimeInUTC, String endTimeInUTC, String creator) {
+      long groupId, String title, long startTime, long endTime, String creator) {
     Transaction eventTransaction = datastore.beginTransaction();
     long eventId = 0;
     try {
       Entity eventEntity = new Entity(EventEntity.KIND.getLabel());
       eventEntity.setProperty(EventEntity.TITLE_PROPERTY.getLabel(), title);
-      eventEntity.setProperty(EventEntity.START_PROPERTY.getLabel(), startTimeInUTC);
-      eventEntity.setProperty(EventEntity.END_PROPERTY.getLabel(), endTimeInUTC);
+      eventEntity.setProperty(EventEntity.START_PROPERTY.getLabel(), startTime);
+      eventEntity.setProperty(EventEntity.END_PROPERTY.getLabel(), endTime);
       eventEntity.setProperty(EventEntity.CREATOR_PROPERTY.getLabel(), creator);
       eventEntity.setProperty(EventEntity.MESSAGES_PROPERTY.getLabel(), new ArrayList<Long>());
       eventEntity.setProperty(EventEntity.ATTENDEES_PROPERTY.getLabel(), new ArrayList<Long>());

--- a/src/main/java/com/google/lecturechat/data/Event.java
+++ b/src/main/java/com/google/lecturechat/data/Event.java
@@ -25,9 +25,9 @@ public final class Event {
   private final long id;
   private final String title;
 
-  // Format for time: YYYY-MM-DDTHH-MM-SS.
-  private final String startTimeInUTC;
-  private final String endTimeInUTC;
+  // The number of milliseconds since epoch time (1 Jan 1970 UTC).
+  private final long startTime;
+  private final long endTime;
 
   private final String creator;
   private final List<Long> messages;
@@ -36,15 +36,15 @@ public final class Event {
   public Event(
       long id,
       String title,
-      String startTimeInUTC,
-      String endTimeInUTC,
+      long startTime,
+      long endTime,
       String creator,
       List<Long> messages,
       List<Long> attendees) {
     this.id = id;
     this.title = title;
-    this.startTimeInUTC = startTimeInUTC;
-    this.endTimeInUTC = endTimeInUTC;
+    this.startTime = startTime;
+    this.endTime = endTime;
     this.creator = creator;
     this.messages = messages;
     this.attendees = attendees;
@@ -58,12 +58,12 @@ public final class Event {
     return title;
   }
 
-  public String getStart() {
-    return startTimeInUTC;
+  public long getStart() {
+    return startTime;
   }
 
-  public String getEnd() {
-    return endTimeInUTC;
+  public long getEnd() {
+    return endTime;
   }
 
   public String getCreator() {
@@ -82,14 +82,14 @@ public final class Event {
     if (eventEntity.getKind().equals(EventEntity.KIND.getLabel())) {
       long id = eventEntity.getKey().getId();
       String title = (String) (eventEntity.getProperty(EventEntity.TITLE_PROPERTY.getLabel()));
-      String start = (String) (eventEntity.getProperty(EventEntity.START_PROPERTY.getLabel()));
-      String end = (String) (eventEntity.getProperty(EventEntity.END_PROPERTY.getLabel()));
+      long startTime = (long) (eventEntity.getProperty(EventEntity.START_PROPERTY.getLabel()));
+      long endTime = (long) (eventEntity.getProperty(EventEntity.END_PROPERTY.getLabel()));
       String creator = (String) (eventEntity.getProperty(EventEntity.CREATOR_PROPERTY.getLabel()));
       List<Long> messages =
           (ArrayList) (eventEntity.getProperty(EventEntity.MESSAGES_PROPERTY.getLabel()));
       List<Long> attendees =
           (ArrayList) (eventEntity.getProperty(EventEntity.ATTENDEES_PROPERTY.getLabel()));
-      return new Event(id, title, start, end, creator, messages, attendees);
+      return new Event(id, title, startTime, endTime, creator, messages, attendees);
     } else {
       throw new IllegalArgumentException(
           "Attempted to create event object from entity that is not an event.");


### PR DESCRIPTION
We will store the number of milliseconds since epoch time (1 Jan 1970 UTC) instead of using unnecessary formatting.