### PR TITLE
Home page menu

### DIFF
--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -234,11 +234,12 @@ function getDateOfTheNextMonth(date) {
 }
 
 /**
+ * TODO: Include unit tests
+ * 
  * Gets the number of days present in the month of the date received.
  * @param {Date} date The date for which we will compute the number of days.
  * @return {Integer} The number of days.
  */
-// TODO: Include unit tests
 function getNumberOfDaysInMonth(date) {
   const year = date.getFullYear();
   const month = date.getMonth();

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -29,8 +29,8 @@ class Event {
   /**
    * Creates a new event with the given parameters.
    * @param {String} title The title of the event.
-   * @param {String} start The start date of the event.
-   * @param {String} end The end date of the event.
+   * @param {Date} start The start date of the event.
+   * @param {Date} end The end date of the event.
    */
   constructor(title, start, end) {
     /** @private @const {String} */
@@ -42,27 +42,24 @@ class Event {
   }
 }
 
-/**
- * Adds the events associated with that date to the element.
- * @param {Date} date The date for which the events will be added.
- * @param {Element} dateElement The element in which the events will be added.
- */
-function addEventsOfTheDay(date, dateElement) {
-  const events = eventsDictionary[date];
-  if (events === undefined) {
-    return;
-  }
-  events.sort(compareEventsByStartDate);
-  dateElement.classList.add('day-with-events');
-  dateElement.addEventListener('click', function() {
-    displayEvents(date);
 
-    const currentlySelectedDay = document.getElementById('selected-day');
-    if (currentlySelectedDay !== null) {
-      currentlySelectedDay.id = '';
-    }
-    dateElement.id = 'selected-day';
+/**
+ * Adds a button that will load the new month determined by the
+ * function received (e.g. previous / next month).
+ * @param {String} buttonClass The class of the button used to identify
+ * the icon.
+ * @param {Element} calendarHeader The header of the calendar.
+ * @param {Date} date The date used to compute the new month.
+ * @param {Function} functionToCreateNewMonth The function used to create
+ * the new month.
+ */
+function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
+    functionToCreateNewMonth) {
+  const newMonthButton = createElement('i', 'material-icons', buttonClass);
+  newMonthButton.addEventListener('click', function() {
+    loadNewMonth(date, functionToCreateNewMonth);
   });
+  calendarHeader.appendChild(newMonthButton);
 }
 
 /**
@@ -101,6 +98,29 @@ function addDaysOfTheMonth(calendarTable, date) {
 }
 
 /**
+ * Adds the events associated with that date to the element.
+ * @param {Date} date The date for which the events will be added.
+ * @param {Element} dateElement The element in which the events will be added.
+ */
+function addEventsOfTheDay(date, dateElement) {
+  const events = eventsDictionary[date];
+  if (events === undefined) {
+    return;
+  }
+  events.sort(compareEventsByStartDate);
+  dateElement.classList.add('day-with-events');
+  dateElement.addEventListener('click', function() {
+    displayEvents(date);
+
+    const currentlySelectedDay = document.getElementById('selected-day');
+    if (currentlySelectedDay !== null) {
+      currentlySelectedDay.id = '';
+    }
+    dateElement.id = 'selected-day';
+  });
+}
+
+/**
  * Adds a header containing details about the current month and two buttons
  * to switch between the previous and the next months.
  * @param {Element} calendarContainer The container that will incorporate the
@@ -114,32 +134,13 @@ function addHeaderOfTheMonth(calendarContainer, date) {
   const calendarHeader = createElement('div', 'calendar-header', '');
 
   addButtonToGetNewMonth('arrow_back_ios', calendarHeader, date,
-      getDateOfThePreviousMonthDate);
+      getDateOfThePreviousMonth);
   calendarHeader.appendChild(createElement('p', 'calendar-details',
       MONTHS[month] + ' ' + year));
   addButtonToGetNewMonth('arrow_forward_ios', calendarHeader, date,
-      getDateOfTheNextMonthDate);
+      getDateOfTheNextMonth);
 
   calendarContainer.appendChild(calendarHeader);
-}
-
-/**
- * Adds a button that will load the new month determined by the
- * function received (e.g. previous / next month).
- * @param {String} buttonClass The class of the button used to identify
- * the icon.
- * @param {Element} calendarHeader The header of the calendar.
- * @param {Date} date The date used to compute the new month.
- * @param {Function} functionToCreateNewMonth The function used to create
- * the new month.
- */
-function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
-    functionToCreateNewMonth) {
-  const newMonthButton = createElement('i', 'material-icons', buttonClass);
-  newMonthButton.addEventListener('click', function() {
-    loadNewMonth(date, functionToCreateNewMonth);
-  });
-  calendarHeader.appendChild(newMonthButton);
 }
 
 /**
@@ -168,6 +169,21 @@ function compareEventsByStartDate(firstEvent, secondEvent) {
 }
 
 /**
+ * Creates the calendar associated with the date given.
+ * @param {Date} date The date for which we want to display the calendar.
+ */
+function createCalendarOfTheMonth(date) {
+  const calendarContainer = document.getElementById('calendar');
+  const calendarTable = createElement('table', 'calendar-table', '');
+
+  addHeaderOfTheMonth(calendarContainer, date);
+  addWeekDaysToCalendar(calendarTable);
+  addDaysOfTheMonth(calendarTable, date);
+
+  calendarContainer.appendChild(calendarTable);
+}
+
+/**
  * Creates the element associated with a given event.
  * @param {object} event The event for which we will create a new element.
  * @return {Element} The element created.
@@ -181,21 +197,6 @@ function createEventElement(event) {
       event.start_ + ' - ' + event.end_));
 
   return eventElement;
-}
-
-/**
- * Creates the calendar associated with the date given.
- * @param {Date} date The date for which we want to display the calendar.
- */
-function createCalendarOfTheMonth(date) {
-  const calendarContainer = document.getElementById('calendar');
-  const calendarTable = createElement('table', 'calendar-table', '');
-
-  addHeaderOfTheMonth(calendarContainer, date);
-  addWeekDaysToCalendar(calendarTable);
-  addDaysOfTheMonth(calendarTable, date);
-
-  calendarContainer.appendChild(calendarTable);
 }
 
 /**
@@ -234,21 +235,6 @@ function getDateOfTheNextMonth(date) {
 }
 
 /**
- * Gets the number of days present in the month of the date received.
- * @param {Date} date The date for which we will compute the number of days.
- * @return {Integer} The number of days.
- */
-function getNumberOfDaysInMonth(date) {
-  const year = date.getFullYear();
-  const month = date.getMonth();
-  const nextMonthDate = getNextMonthDate(new Date(year, month));
-  const nextMonthYear = nextMonthDate.getFullYear();
-  const nextMonth = nextMonthDate.getMonth();
-
-  return new Date(nextMonthYear, nextMonth, 0).getDate();
-}
-
-/**
  * Gets the previous month of the date received.
  * @param {Date} date The date for which the new date will be created.
  * @return {Date} The date of the previous month.
@@ -262,6 +248,21 @@ function getDateOfThePreviousMonth(date) {
   }
 
   return new Date(currentYear, currentMonth - 1);
+}
+
+/**
+ * Gets the number of days present in the month of the date received.
+ * @param {Date} date The date for which we will compute the number of days.
+ * @return {Integer} The number of days.
+ */
+function getNumberOfDaysInMonth(date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const nextMonthDate = getDateOfTheNextMonth(new Date(year, month));
+  const nextMonthYear = nextMonthDate.getFullYear();
+  const nextMonth = nextMonthDate.getMonth();
+
+  return new Date(nextMonthYear, nextMonth, 0).getDate();
 }
 
 /**

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -238,6 +238,7 @@ function getDateOfTheNextMonth(date) {
  * @param {Date} date The date for which we will compute the number of days.
  * @return {Integer} The number of days.
  */
+// TODO: Include unit tests
 function getNumberOfDaysInMonth(date) {
   const year = date.getFullYear();
   const month = date.getMonth();

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -235,7 +235,7 @@ function getDateOfTheNextMonth(date) {
 
 /**
  * TODO: Include unit tests
- * 
+ *
  * Gets the number of days present in the month of the date received.
  * @param {Date} date The date for which we will compute the number of days.
  * @return {Integer} The number of days.

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -42,24 +42,27 @@ class Event {
   }
 }
 
-
 /**
- * Adds a button that will load the new month determined by the
- * function received (e.g. previous / next month).
- * @param {String} buttonClass The class of the button used to identify
- * the icon.
- * @param {Element} calendarHeader The header of the calendar.
- * @param {Date} date The date used to compute the new month.
- * @param {Function} functionToCreateNewMonth The function used to create
- * the new month.
+ * Adds the events associated with that date to the element.
+ * @param {Date} date The date for which the events will be added.
+ * @param {Element} dateElement The element in which the events will be added.
  */
-function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
-    functionToCreateNewMonth) {
-  const newMonthButton = createElement('i', 'material-icons', buttonClass);
-  newMonthButton.addEventListener('click', function() {
-    loadNewMonth(date, functionToCreateNewMonth);
+function addEventsOfTheDay(date, dateElement) {
+  const events = eventsDictionary[date];
+  if (events === undefined) {
+    return;
+  }
+  events.sort(compareEventsByStartDate);
+  dateElement.classList.add('day-with-events');
+  dateElement.addEventListener('click', function() {
+    displayEvents(date);
+
+    const currentlySelectedDay = document.getElementById('selected-day');
+    if (currentlySelectedDay !== null) {
+      currentlySelectedDay.id = '';
+    }
+    dateElement.id = 'selected-day';
   });
-  calendarHeader.appendChild(newMonthButton);
 }
 
 /**
@@ -98,29 +101,6 @@ function addDaysOfTheMonth(calendarTable, date) {
 }
 
 /**
- * Adds the events associated with that date to the element.
- * @param {Date} date The date for which the events will be added.
- * @param {Element} dateElement The element in which the events will be added.
- */
-function addEventsOfTheDay(date, dateElement) {
-  const events = eventsDictionary[date];
-  if (events === undefined) {
-    return;
-  }
-  events.sort(compareEventsByStartDate);
-  dateElement.classList.add('day-with-events');
-  dateElement.addEventListener('click', function() {
-    displayEvents(date);
-
-    const currentlySelectedDay = document.getElementById('selected-day');
-    if (currentlySelectedDay !== null) {
-      currentlySelectedDay.id = '';
-    }
-    dateElement.id = 'selected-day';
-  });
-}
-
-/**
  * Adds a header containing details about the current month and two buttons
  * to switch between the previous and the next months.
  * @param {Element} calendarContainer The container that will incorporate the
@@ -141,6 +121,25 @@ function addHeaderOfTheMonth(calendarContainer, date) {
       getDateOfTheNextMonth);
 
   calendarContainer.appendChild(calendarHeader);
+}
+
+/**
+ * Adds a button that will load the new month determined by the
+ * function received (e.g. previous / next month).
+ * @param {String} buttonClass The class of the button used to identify
+ * the icon.
+ * @param {Element} calendarHeader The header of the calendar.
+ * @param {Date} date The date used to compute the new month.
+ * @param {Function} functionToCreateNewMonth The function used to create
+ * the new month.
+ */
+function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
+    functionToCreateNewMonth) {
+  const newMonthButton = createElement('i', 'material-icons', buttonClass);
+  newMonthButton.addEventListener('click', function() {
+    loadNewMonth(date, functionToCreateNewMonth);
+  });
+  calendarHeader.appendChild(newMonthButton);
 }
 
 /**
@@ -169,21 +168,6 @@ function compareEventsByStartDate(firstEvent, secondEvent) {
 }
 
 /**
- * Creates the calendar associated with the date given.
- * @param {Date} date The date for which we want to display the calendar.
- */
-function createCalendarOfTheMonth(date) {
-  const calendarContainer = document.getElementById('calendar');
-  const calendarTable = createElement('table', 'calendar-table', '');
-
-  addHeaderOfTheMonth(calendarContainer, date);
-  addWeekDaysToCalendar(calendarTable);
-  addDaysOfTheMonth(calendarTable, date);
-
-  calendarContainer.appendChild(calendarTable);
-}
-
-/**
  * Creates the element associated with a given event.
  * @param {object} event The event for which we will create a new element.
  * @return {Element} The element created.
@@ -197,6 +181,21 @@ function createEventElement(event) {
       event.start_ + ' - ' + event.end_));
 
   return eventElement;
+}
+
+/**
+ * Creates the calendar associated with the date given.
+ * @param {Date} date The date for which we want to display the calendar.
+ */
+function createCalendarOfTheMonth(date) {
+  const calendarContainer = document.getElementById('calendar');
+  const calendarTable = createElement('table', 'calendar-table', '');
+
+  addHeaderOfTheMonth(calendarContainer, date);
+  addWeekDaysToCalendar(calendarTable);
+  addDaysOfTheMonth(calendarTable, date);
+
+  calendarContainer.appendChild(calendarTable);
 }
 
 /**
@@ -235,6 +234,21 @@ function getDateOfTheNextMonth(date) {
 }
 
 /**
+ * Gets the number of days present in the month of the date received.
+ * @param {Date} date The date for which we will compute the number of days.
+ * @return {Integer} The number of days.
+ */
+function getNumberOfDaysInMonth(date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const nextMonthDate = getDateOfTheNextMonth(new Date(year, month));
+  const nextMonthYear = nextMonthDate.getFullYear();
+  const nextMonth = nextMonthDate.getMonth();
+
+  return new Date(nextMonthYear, nextMonth, 0).getDate();
+}
+
+/**
  * Gets the previous month of the date received.
  * @param {Date} date The date for which the new date will be created.
  * @return {Date} The date of the previous month.
@@ -248,21 +262,6 @@ function getDateOfThePreviousMonth(date) {
   }
 
   return new Date(currentYear, currentMonth - 1);
-}
-
-/**
- * Gets the number of days present in the month of the date received.
- * @param {Date} date The date for which we will compute the number of days.
- * @return {Integer} The number of days.
- */
-function getNumberOfDaysInMonth(date) {
-  const year = date.getFullYear();
-  const month = date.getMonth();
-  const nextMonthDate = getDateOfTheNextMonth(new Date(year, month));
-  const nextMonthYear = nextMonthDate.getFullYear();
-  const nextMonth = nextMonthDate.getMonth();
-
-  return new Date(nextMonthYear, nextMonth, 0).getDate();
 }
 
 /**
@@ -282,7 +281,7 @@ function loadCalendar() {
  * Fetches events from the server and stores them in the dictionary.
  */
 async function loadEvents() {
-  const response = await fetch('/events');
+  const response = await fetch('/user-events');
   const events = await response.json();
 
   events.forEach((event) => {
@@ -290,7 +289,7 @@ async function loadEvents() {
     const eventEndDate = new Date(event.end);
     const eventStartDay = new Date(eventStartDate.getFullYear(),
         eventStartDate.getMonth(), eventStartDate.getDate());
-    const eventObject = new Event(event.name, eventStartDate,
+    const eventObject = new Event(event.title, eventStartDate,
         eventEndDate);
 
     if (eventStartDay in eventsDictionary) {
@@ -313,4 +312,4 @@ function loadNewMonth(date, functionToCreateNewMonth) {
   createCalendarOfTheMonth(newMonthDate);
 }
 
-export {loadEvents, loadCalendar};
+export {createEventElement, Event, loadEvents, loadCalendar};

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 import {createElement} from './script.js';
+import {createEventElement, Event} from './events-script.js';
 
 /** Class used to define the basic characteristics of a group. */
 class Group {
@@ -35,6 +36,24 @@ class Group {
     /** @private @const {int} */
     this.year_ = year;
   }
+}
+
+/**
+ * Adds a new event to the group specified.
+ * @param {load} groupId The id of the group to which we will add the event.
+ */
+function addNewEvent(groupId) {
+  const params = new URLSearchParams();
+  const title = document.getElementById('new-event-title').value;
+  const start = Date.parse(document.getElementById('new-event-start').value);
+  const end = Date.parse(document.getElementById('new-event-end').value);
+
+  params.append('group-id', groupId);
+  params.append('title', title);
+  params.append('start', start);
+  params.append('end', end);
+
+  fetch('/group-events', {method: 'POST', body: params});
 }
 
 /**
@@ -64,11 +83,22 @@ function changeContainerDisplay(containerID, displayType) {
 }
 
 /**
- * Closes the new group form and displays the "Create new group" button.
+ * Closes the form with the given type (e.g. group, event) and displays
+ * the button associated.
+ * @param {String} formType The form type that is included in the ids of the
+ * form and of the button.
  */
-function closeGroupForm() {
-  changeContainerDisplay('group-form', 'none');
-  changeContainerDisplay('open-group-form', 'initial');
+function closeForm(formType) {
+  changeContainerDisplay(formType + '-form', 'none');
+  changeContainerDisplay('open-' + formType + '-form', 'initial');
+}
+
+/**
+ * Closes the list of events opened.
+ */
+function closeListOfEvents() {
+  changeContainerDisplay('list-of-events', 'none');
+  changeContainerDisplay('groups-section', 'initial');
 }
 
 /**
@@ -113,6 +143,10 @@ function createGroupElement(group) {
   groupElement.appendChild(createElement('div', 'group-details',
       createDetailsMessage(group.degree_, group.year_)));
 
+  groupElement.addEventListener('click', function() {
+    showListOfEvents(group.id_);
+  });
+
   return groupElement;
 }
 
@@ -128,10 +162,34 @@ function joinGroup(groupId) {
 }
 
 /**
- * Fetches groups from the server and adds them to the groups section.
+ * Fetches the events associated with the group from the server.
+ * @param {Object} groupId The group id.
+ */
+async function loadGroupEvents(groupId) {
+  const eventsContainer = document.getElementById('group-events');
+  eventsContainer.innerHTML = '';
+
+  const url = new URL('/group-events', window.location.origin);
+  const params = new URLSearchParams();
+  params.append('group-id', groupId);
+  url.search = params;
+
+  const response = await fetch(url);
+  const events = await response.json();
+
+  events.forEach((event) => {
+    const eventStartTime = new Date(event.startTime);
+    const eventEndDate = new Date(event.endTime);
+    const eventObject = new Event(event.title, eventStartTime, eventEndDate);
+    eventsContainer.appendChild(createEventElement(eventObject));
+  });
+}
+
+/**
+ * Fetches the groups from the server and adds them to the groups section.
  */
 function loadGroups() {
-  const groupsList = document.getElementById('groups');
+  const groupsList = document.getElementById('groups-container');
   groupsList.innerHTML = '';
 
   fetch('/groups')
@@ -146,15 +204,35 @@ function loadGroups() {
 }
 
 /**
- * Opens the new group form and hides the "Create new group" button.
+ * Opens the form with the given type (e.g. group, event) and hides
+ * the button associated.
+ * @param {String} formType The form type that is included in the ids of the
+ * form and of the button.
  */
-function openGroupForm() {
-  changeContainerDisplay('group-form', 'block');
-  changeContainerDisplay('open-group-form', 'none');
+function openForm(formType) {
+  changeContainerDisplay(formType + '-form', 'block');
+  changeContainerDisplay('open-' + formType + '-form', 'none');
+}
+
+/**
+ * Shows the events of the group as a list.
+ * @param {long} groupId The group id.
+ */
+async function showListOfEvents(groupId) {
+  changeContainerDisplay('list-of-events', 'initial');
+  changeContainerDisplay('groups-section', 'none');
+
+  await loadGroupEvents(groupId);
+
+  const eventForm = document.getElementById('new-event-form');
+  eventForm.onsubmit = function() {
+    addNewEvent(groupId);
+  };
 }
 
 window.addNewGroup = addNewGroup;
-window.closeGroupForm = closeGroupForm;
-window.openGroupForm = openGroupForm;
+window.closeListOfEvents = closeListOfEvents;
+window.closeForm = closeForm;
+window.openForm = openForm;
 
 export {loadGroups};

--- a/src/main/webapp/home-page-script.js
+++ b/src/main/webapp/home-page-script.js
@@ -14,9 +14,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {initClient, createElement, loadProfileData, signOut} from './script.js';
+import {initClient, loadProfileData, signOut} from './script.js';
 import {loadGroups} from './groups-script.js';
 import {loadEvents, loadCalendar} from './events-script.js';
+
+/**
+ * Gets the section ID from the option element.
+ * @param {Element} option The menu option associated with the section.
+ * @return {String} The section ID.
+ */
+function getSectionIdFromOption(option) {
+  return option.innerHTML.trim().toLowerCase();
+}
 
 /**
  * Initializes the client and loads the data associated with their profile.
@@ -45,5 +54,26 @@ async function loadProfile() {
   loadGroups();
 }
 
+/**
+ * Shows the new section by hiding the current active section.
+ * @param {Element} activeOption The menu option linked to the section
+ * to be displayed.
+ */
+function showSection(activeOption) {
+  const currentActiveOption = document.getElementById('active-option');
+  const currentActiveSectionId = getSectionIdFromOption(currentActiveOption);
+  const currentActiveSection = document.getElementById(currentActiveSectionId);
+
+  currentActiveOption.id = '';
+  currentActiveSection.classList.remove('active-section');
+
+  const activeSectionId = getSectionIdFromOption(activeOption);
+  const activeSection = document.getElementById(activeSectionId);
+
+  activeOption.id = 'active-option';
+  activeSection.classList.add('active-section');
+}
+
+window.showSection = showSection;
 window.signOut = signOut;
 loadHomeClient('auth');

--- a/src/main/webapp/home-page-style.css
+++ b/src/main/webapp/home-page-style.css
@@ -1,3 +1,7 @@
+#active-option {
+  color: #c0c0c0;
+}
+
 body {
   font-family: Assistant, sans-serif;
 }
@@ -38,7 +42,7 @@ body {
   width: 100%;
 }
 
-.close-group-form {
+.close-form {
   cursor: pointer;
   font-size: 40px;
   font-weight: bold;
@@ -60,18 +64,11 @@ body {
   width: 100%;
 }
 
-.event-title,
 .event-time,
+.event-title,
 .group-details,
 .group-university {
   padding: 20px;
-}
-
-.event-title,
-.group-university {
-  font-size: 20px;
-  font-weight: bold;
-  padding-bottom: 0;
 }
 
 .event-time,
@@ -81,11 +78,28 @@ body {
   padding-top: 0;
 }
 
+.event-title,
+.group-university {
+  font-size: 20px;
+  font-weight: bold;
+  padding-bottom: 0;
+}
+
 #events-container {
   display: inline;
 }
 
-#group-form {
+.form-headline {
+  display: flex;
+  justify-content: space-between;
+}
+
+.group:hover {
+  cursor: pointer;
+}
+
+#group-form,
+#event-form {
   background-color: #008b8b;
   color: white;
   display: none;
@@ -113,6 +127,10 @@ input:focus {
 
 label {
   font-weight: bold;
+}
+
+#list-of-events {
+  display: none;
 }
 
 .main {
@@ -155,11 +173,11 @@ label {
   padding-top: 20px;
 }
 
-.new-group-headline {
-  display: flex;
-  justify-content: space-between;
+.menu-section:not(.active-section) {
+  display: none;
 }
 
+#open-event-form,
 #open-group-form {
   background-color: #008b8b;
   border: none;
@@ -174,10 +192,12 @@ label {
   padding: 10px;
 }
 
+#open-event-form:active,
 #open-group-form:active {
   outline: none;
 }
 
+#open-event-form:hover,
 #open-group-form:hover {
   opacity: 1;
 }
@@ -190,11 +210,24 @@ label {
   width: 150px;
 }
 
+.sign-out-button {
+  bottom: 0;
+  box-sizing: border-box;
+  cursor: pointer;
+  font-size: 25px;
+  font-weight: bold;
+  padding-bottom: 20px;
+  padding-right: 20px;
+  position: fixed;
+  text-align: right;
+  width: 200px;
+}
+
 #selected-day {
   background-color: #008b8b;
 }
 
-.submit-group-form {
+.submit-form {
   background-color: #096b72;
   border: none;
   color: white;
@@ -213,19 +246,6 @@ label {
 
 .submit-group-form:hover {
   opacity: 1;
-}
-
-.sign-out-button {
-  bottom: 0;
-  box-sizing: border-box;
-  cursor: pointer;
-  font-size: 25px;
-  font-weight: bold;
-  padding-bottom: 20px;
-  padding-right: 20px;
-  position: fixed;
-  text-align: right;
-  width: 200px;
 }
 
 td,

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -1,3 +1,4 @@
+ 
 <!DOCTYPE html>
 <html>
   <head>
@@ -13,11 +14,11 @@
   <body>
     <div id="menu">
       <div class="menu-options">
-        <a class="menu-option">
+        <a class="menu-option" id="active-option" onclick="showSection(this)">
           Home
         </a>
-        <a class="menu-option">
-          Settings
+        <a class="menu-option" onclick="showSection(this)">
+          Groups
         </a>
       </div>
       <a class="sign-out-button" onclick="signOut()">
@@ -25,52 +26,96 @@
       </a>
     </div>
     <div class="main">
-      <table id="calendar">
-      </table>
-      <div id="events-container">
-        <h2>
-          Your events
-        </h2>
-        <div id="events">
-        </div>
-      </div>
-      <div id="groups-container">
-        <h2>
-          Your groups
-        </h2>
-        <div id="groups">
-        </div>
-      </div>
-      <button id="open-group-form" onclick="openGroupForm()">
-        Create new group
-      </button>
-      <div id="group-form">
-        <form autocomplete="off" onsubmit="addNewGroup()">
-          <div class="new-group-headline">
-            <h1>
-              Add new group
-            </h1>
-            <span class="close-group-form" onclick="closeGroupForm()">
-              x
-            </span>
+      <div class="menu-section active-section" id="home">
+        <table id="calendar">
+        </table>
+        <div id="events-container">
+          <h2>
+            Your events
+          </h2>
+          <div id="events">
           </div>
-          <label for="new-group-university">
-            University
-          </label>
-          <input type="text" placeholder="Enter the name of the university..." name="university" required id="new-group-university">
-          <label for="new-group-degree">
-            Degree
-          </label>
-          <input type="text" placeholder="Enter the name of the degree..." name="degree" required id="new-group-degree">
-          <label for="new-group-year">
-            Year
-          </label>
-          <input type="numerical" placeholder="Enter your current year..." name="year" required id="new-group-year">
-          <hr>
-          <button class="submit-group-form" type="submit">
-            Create the group
+        </div>
+      </div>
+      <div class="menu-section" id="groups">
+        <div id="groups-section">
+          <h2>
+            Your groups
+          </h2>
+          <div id="groups-container">
+          </div>
+          <button id="open-group-form" onclick="openForm('group')">
+            Create new group
           </button>
-        </form>
+          <div id="group-form">
+            <form autocomplete="off" onsubmit="addNewGroup()">
+              <div class="form-headline">
+                <h1>
+                  Add new group
+                </h1>
+                <span class="close-form" onclick="closeForm('group')">
+                  x
+                </span>
+              </div>
+              <label for="new-group-university">
+                University
+              </label>
+              <input type="text" placeholder="Enter the name of the university..." name="university" required id="new-group-university">
+              <label for="new-group-degree">
+                Degree
+              </label>
+              <input type="text" placeholder="Enter the name of the degree..." name="degree" required id="new-group-degree">
+              <label for="new-group-year">
+                Year
+              </label>
+              <input type="numerical" placeholder="Enter your current year..." name="year" required id="new-group-year">
+              <hr>
+              <button class="submit-form" type="submit">
+                Create the group
+              </button>
+            </form>
+          </div>
+        </div>
+        <div id="list-of-events">
+          <div id="group-headline">
+            <i class="material-icons" onclick="closeListOfEvents()">
+              keyboard_backspace
+            </i>
+          </div>
+          <div id="group-events">
+          </div>
+          <button id="open-event-form" onclick="openForm('event')">
+            Create new event
+          </button>
+          <div id="event-form">
+            <form autocomplete="off" id="new-event-form">
+              <div class="form-headline">
+                <h1>
+                  Add new event
+                </h1>
+                <span class="close-form" onclick="closeForm('event')">
+                  x
+                </span>
+              </div>
+              <label for="new-event-title">
+                Title
+              </label>
+              <input type="text" placeholder="Enter the title of the event..." name="title" required id="new-event-title">
+              <label for="new-event-start">
+                Start date
+              </label>
+              <input type="datetime-local" placeholder="Enter the start date of the event..." name="start" required id="new-event-start">
+              <label for="new-event-end">
+                End date
+              </label>
+              <input type="datetime-local" placeholder="Enter the end date of the event..." name="end" required id="new-event-end">
+              <hr>
+              <button class="submit-form" type="submit">
+                Create the event
+              </button>
+            </form>
+          </div>
+        </div>
       </div>
     </div>
   </body>

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -1,5 +1,4 @@
- 
-<!DOCTYPE html>
+ <!DOCTYPE html>
 <html>
   <head>
     <title>LectureChat</title>

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -1,4 +1,4 @@
- <!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>LectureChat</title>


### PR DESCRIPTION
This pull request also contains the updates from #13. It will be updated afterwards if needed.

The main purpose of this pull request is to integrate a functional lateral menu that can used to switch between different types of sections. Additionally it assumes that some servlets are already defined (we will include them in the next pull requests since the changes are quite big to be reviewed easily). That being said, the changes are focused on the front-end side as follows:
- The groups are separated into a new section that can be displayed from the lateral menu.
- The list of events associated with a group can be opened by clicking on the group. It also includes a form to create a new event.

I used the following restraint:
_The section associated with one of the options on the lateral menu has the same ID as the text incorporated in that option (case insensitive). In this way, once I know the option I can easily identify the section without checking other sections. This will be later modified since it allows only single word options._