### PR TITLE
Include joining functionality

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -357,9 +357,22 @@ public class DatastoreAccess {
    * @param userId The id of the user.
    * @return The list of groups that the user didn't join yet.
    */
-  public List<Group> getOtherGroups(String userId) {
+  public List<Group> getNotJoinedGroups(String userId) {
     List<Group> groups = getAllGroups();
     groups.removeAll(getJoinedGroups(userId));
     return groups;
+  }
+
+  /**
+   * Gets all the events in a certain group that the user didn't join yet.
+   *
+   * @param groupId The id of the group.
+   * @param userId The id of the user.
+   * @return The list of events that the user didn't join yet.
+   */
+  public List<Event> getAllNotJoinedEventsFromGroup(long groupId, String userId) {
+    List<Event> events = getAllEventsFromGroup(groupId);
+    events.removeAll(getJoinedEvents(userId));
+    return events;
   }
 }

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -257,13 +257,14 @@ public class DatastoreAccess {
    * @param entityLabel The label associated with this entity.
    */
   public void joinEntity(String userId, long entityId, String entityLabel) {
-    if (!isUserRegistered(userId)) {
+    Optional<Entity> entity = getEntityByIdString(UserEntity.KIND.getLabel(), userId);
+    if (!entity.isPresent()) {
       return;
     }
 
     Transaction transaction = datastore.beginTransaction();
     try {
-      Entity userEntity = getEntityByIdString(UserEntity.KIND.getLabel(), userId).get();
+      Entity userEntity = entity.get();
       List<Long> entitiesIds = (ArrayList) (userEntity.getProperty(entityLabel));
       if (entitiesIds == null) {
         entitiesIds = new ArrayList<>();
@@ -310,11 +311,12 @@ public class DatastoreAccess {
    * @return The list of the groups joined.
    */
   public List<Group> getJoinedGroups(String userId) {
-    if (!isUserRegistered(userId)) {
+    Optional<Entity> entity = getEntityByIdString(UserEntity.KIND.getLabel(), userId);
+    if (!entity.isPresent()) {
       return new ArrayList<>();
     }
 
-    Entity userEntity = getEntityByIdString(UserEntity.KIND.getLabel(), userId).get();
+    Entity userEntity = entity.get();
     List<Long> groupsIds =
         (ArrayList) (userEntity.getProperty(UserEntity.GROUPS_PROPERTY.getLabel()));
     if (groupsIds == null) {
@@ -334,11 +336,12 @@ public class DatastoreAccess {
    * @return The list of the events joined.
    */
   public List<Event> getJoinedEvents(String userId) {
-    if (!isUserRegistered(userId)) {
+    Optional<Entity> entity = getEntityByIdString(UserEntity.KIND.getLabel(), userId);
+    if (!entity.isPresent()) {
       return new ArrayList<>();
     }
 
-    Entity userEntity = getEntityByIdString(UserEntity.KIND.getLabel(), userId).get();
+    Entity userEntity = entity.get();
     List<Long> eventsIds =
         (ArrayList) (userEntity.getProperty(UserEntity.EVENTS_PROPERTY.getLabel()));
     if (eventsIds == null) {
@@ -349,5 +352,17 @@ public class DatastoreAccess {
             eventId ->
                 Event.createEventFromEntity(getEntityById(EventEntity.KIND.getLabel(), eventId)))
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Gets only the groups that the user isn't part of already.
+   *
+   * @param userId The id of the user.
+   * @return The list of groups that the user didn't join yet.
+   */
+  public List<Group> getOtherGroups(String userId) {
+    List<Group> groups = getAllGroups();
+    groups.removeAll(getJoinedGroups(userId));
+    return groups;
   }
 }

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -215,7 +215,7 @@ public class DatastoreAccess {
    * @param groupId The id of the group.
    * @return The list of events.
    */
-  public List<Event> getAllEventsFromGroup(long groupId) {
+  private List<Event> getAllEventsFromGroup(long groupId) {
     Entity groupEntity = getEntityById(GroupEntity.KIND.getLabel(), groupId);
     List<Long> eventIds =
         (ArrayList) (groupEntity.getProperty(GroupEntity.EVENTS_PROPERTY.getLabel()));

--- a/src/main/java/com/google/lecturechat/data/Event.java
+++ b/src/main/java/com/google/lecturechat/data/Event.java
@@ -101,7 +101,6 @@ public final class Event {
     if (!(anotherObject instanceof Event)) {
       return false;
     }
-    Event anotherEvent = (Event) anotherObject;
-    return (this.getId() == anotherEvent.getId());
+    return (this.getId() == ((Event) anotherObject).getId());
   }
 }

--- a/src/main/java/com/google/lecturechat/data/Event.java
+++ b/src/main/java/com/google/lecturechat/data/Event.java
@@ -95,4 +95,13 @@ public final class Event {
           "Attempted to create event object from entity that is not an event.");
     }
   }
+
+  @Override
+  public boolean equals(Object anotherObject) {
+    if (!(anotherObject instanceof Event)) {
+      return false;
+    }
+    Event anotherEvent = (Event) anotherObject;
+    return (this.getId() == anotherEvent.getId());
+  }
 }

--- a/src/main/java/com/google/lecturechat/data/Group.java
+++ b/src/main/java/com/google/lecturechat/data/Group.java
@@ -81,4 +81,13 @@ public final class Group {
           "Attempted to create group object from entity that is not a group.");
     }
   }
+
+  @Override
+  public boolean equals(Object anotherObject) {
+    if (!(anotherObject instanceof Group)) {
+      return false;
+    }
+    Group anotherGroup = (Group) anotherObject;
+    return (this.getId() == anotherGroup.getId());
+  }
 }

--- a/src/main/java/com/google/lecturechat/data/Group.java
+++ b/src/main/java/com/google/lecturechat/data/Group.java
@@ -87,7 +87,6 @@ public final class Group {
     if (!(anotherObject instanceof Group)) {
       return false;
     }
-    Group anotherGroup = (Group) anotherObject;
-    return (this.getId() == anotherGroup.getId());
+    return (this.getId() == ((Group) anotherObject).getId());
   }
 }

--- a/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
@@ -44,13 +44,15 @@ public class GroupEventsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    if (!AuthStatus.isSignedIn(request)) {
+    Optional<String> userId = AuthStatus.getUserId(request);
+
+    if (!userId.isPresent()) {
       return;
     }
 
     try {
       long groupId = Long.parseLong(request.getParameter(GROUP_ID_PARAMETER));
-      List<Event> events = datastore.getAllEventsFromGroup(groupId);
+      List<Event> events = datastore.getAllNotJoinedEventsFromGroup(groupId, userId.get());
       response.setContentType("application/json;");
       response.setCharacterEncoding("UTF-8");
       Gson gson = new Gson();

--- a/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
@@ -27,8 +27,10 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
-/** Servlet for adding a new event to a group and listing all the events of that group that the
-    user didn't join yet.*/
+/**
+ * Servlet for adding a new event to a group and listing all the events of that group that the user
+ * didn't join yet.
+ */
 @WebServlet("/group-events")
 public class GroupEventsServlet extends HttpServlet {
 

--- a/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
@@ -27,7 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
-/** Servlet for listing all the events of a group and adding a new event to that group. */
+/** Servlet for adding a new event to a group and listing all the events of that group that the
+    user didn't join yet.*/
 @WebServlet("/group-events")
 public class GroupEventsServlet extends HttpServlet {
 

--- a/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
@@ -27,7 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
-/** Servlet for listing all available groups and adding a new group. */
+/** Servlet for adding a new group and listing all the groups that the user didn't join yet. */
 @WebServlet("/groups")
 public class GroupsServlet extends HttpServlet {
 

--- a/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
@@ -43,11 +43,13 @@ public class GroupsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    if (!AuthStatus.isSignedIn(request)) {
+    Optional<String> userId = AuthStatus.getUserId(request);
+
+    if (!userId.isPresent()) {
       return;
     }
 
-    List<Group> groups = datastore.getAllGroups();
+    List<Group> groups = datastore.getNotJoinedGroups(userId.get());
     response.setContentType("application/json;");
     response.setCharacterEncoding("UTF-8");
     Gson gson = new Gson();

--- a/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
@@ -20,6 +20,7 @@ import com.google.lecturechat.data.DatastoreAccess;
 import com.google.lecturechat.data.Group;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -42,10 +43,10 @@ public class GroupsServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    boolean isSignedIn = AuthStatus.isSignedIn(request);
+    Optional<String> userId = AuthStatus.getUserId(request);
 
-    if (isSignedIn) {
-      List<Group> groups = datastore.getAllGroups();
+    if (userId.isPresent()) {
+      List<Group> groups = datastore.getOtherGroups(userId.get());
       response.setContentType("application/json;");
       response.setCharacterEncoding("UTF-8");
       Gson gson = new Gson();

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -172,11 +172,13 @@ function addChatroomButton(eventOptionsElement) {
  */
 function addEventOptions(event, eventElement, hasJoined) {
   const eventOptionsElement = createElement('div', '', '');
-  if (!hasJoined) {
-    addJoinEventButton(event.id_, eventOptionsElement, eventElement);
-  } else {
+
+  if (hasJoined) {
     addChatroomButton(eventOptionsElement);
+  } else {
+    addJoinEventButton(event.id_, eventOptionsElement, eventElement);
   }
+
   eventElement.appendChild(eventOptionsElement);
 }
 

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -343,7 +343,7 @@ function getDateOfThePreviousMonth(date) {
 
 /**
  * Joins the event by sending the request to the server.
- * @param {String} eventId The id of the event that the current user will join.
+ * @param {String} eventId The id of the event that the user will join.
  */
 function joinEvent(eventId) {
   const params = new URLSearchParams();

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -185,6 +185,8 @@ function addEventOptions(event, eventElement, hasJoined) {
 /**
  * Adds a join button through which the user can join that event.
  * @param {Object} eventId The id of the event that will be joined by the user.
+ * @param {Element} eventOptionsElement The element that will include this
+ * button.
  * @param {Element} eventElement The element associated with this event.
  */
 function addJoinEventButton(eventId, eventOptionsElement, eventElement) {

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -28,11 +28,14 @@ const eventsDictionary = {};
 class Event {
   /**
    * Creates a new event with the given parameters.
+   * @param {Long} id The id used to store the event in the database.
    * @param {String} title The title of the event.
    * @param {Date} start The start date of the event.
    * @param {Date} end The end date of the event.
    */
-  constructor(title, start, end) {
+  constructor(id, title, start, end) {
+    /** @private @const {LOng} */
+    this.id_ = id;
     /** @private @const {String} */
     this.title_ = title;
     /** @private @const {String} */
@@ -43,11 +46,20 @@ class Event {
 }
 
 /**
- * Adds the events associated with that date to the element.
+ * Adds the events associated with that date to the element. Today will be
+ * displayed by default.
  * @param {Date} date The date for which the events will be added.
  * @param {Element} dateElement The element in which the events will be added.
  */
 function addEventsOfTheDay(date, dateElement) {
+  const currentDate = new Date();
+  const today = new Date(currentDate.getFullYear(), currentDate.getMonth(),
+      currentDate.getDate());
+
+  if (date.getTime() == today.getTime()) {
+    displayEventsAndMarkDay(date, dateElement);
+  }
+
   const events = eventsDictionary[date];
   if (events === undefined) {
     return;
@@ -55,14 +67,24 @@ function addEventsOfTheDay(date, dateElement) {
   events.sort(compareEventsByStartDate);
   dateElement.classList.add('day-with-events');
   dateElement.addEventListener('click', function() {
-    displayEvents(date);
-
-    const currentlySelectedDay = document.getElementById('selected-day');
-    if (currentlySelectedDay !== null) {
-      currentlySelectedDay.id = '';
-    }
-    dateElement.id = 'selected-day';
+    displayEventsAndMarkDay(date, dateElement);
   });
+}
+
+/**
+ * Displays the evnts from the date received and marks the element as the one
+ * containing the selected day.
+ * @param {Date} date The date for which the events will be displayed.
+ * @param {Element} dateElement The element containing the selected day.
+ */
+function displayEventsAndMarkDay(date, dateElement) {
+  displayEvents(date);
+
+  const currentlySelectedDay = document.getElementById('selected-day');
+  if (currentlySelectedDay !== null) {
+    currentlySelectedDay.id = '';
+  }
+  dateElement.id = 'selected-day';
 }
 
 /**
@@ -143,6 +165,51 @@ function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
 }
 
 /**
+ * Adds a button that can be used to open the chatroom of the event.
+ * @param {Element} eventOptionsElement The element that will include this
+ * button.
+ */
+function addChatroomButton(eventOptionsElement) {
+  const chatroomButton = createElement('button', 'rounded-button', 'Chatroom');
+  chatroomButton.addEventListener('click', function() {
+    // TODO: redirect the user to the chatroom
+  });
+  eventOptionsElement.appendChild(chatroomButton);
+}
+
+/**
+ * Adds the event options available based on the user status (if the user joins
+ * the event or not).
+ * @param {Object} event The object containing the data associated with that
+ * event.
+ * @param {Element} eventElement The element associated with this event.
+ * @param {Boolean} hasJoined Indicates if the user has joined the event.
+ */
+function addEventOptions(event, eventElement, hasJoined) {
+  const eventOptionsElement = createElement('div', '', '');
+  if (!hasJoined) {
+    addJoinEventButton(event.id_, eventOptionsElement, eventElement);
+  } else {
+    addChatroomButton(eventOptionsElement);
+  }
+  eventElement.appendChild(eventOptionsElement);
+}
+
+/**
+ * Adds a join button through which the user can join that event.
+ * @param {Object} eventId The id of the event that will be joined by the user.
+ * @param {Element} eventElement The element associated with this event.
+ */
+function addJoinEventButton(eventId, eventOptionsElement, eventElement) {
+  const joinEventButton = createElement('button', 'rounded-button', 'Join');
+  joinEventButton.addEventListener('click', function() {
+    joinEvent(eventId);
+    eventElement.remove();
+  });
+  eventOptionsElement.appendChild(joinEventButton);
+}
+
+/**
  * Adds the week days header in the calendar's table.
  * @param {Element} calendarTable The table that is part of the calendar.
  */
@@ -169,16 +236,18 @@ function compareEventsByStartDate(firstEvent, secondEvent) {
 
 /**
  * Creates the element associated with a given event.
- * @param {object} event The event for which we will create a new element.
+ * @param {Object} event The event for which we will create a new element.
+ * @param {Boolean} hasJoined True if the user has joined the event, false otherwise.
  * @return {Element} The element created.
  */
-function createEventElement(event) {
+function createEventElement(event, hasJoined) {
   const eventElement = createElement('div', 'event', '');
 
   eventElement.appendChild(createElement('div', 'event-title', event.title_));
   eventElement.appendChild(createElement('hr', '', ''));
   eventElement.appendChild(createElement('div', 'event-time',
       event.start_ + ' - ' + event.end_));
+  addEventOptions(event, eventElement, hasJoined);
 
   return eventElement;
 }
@@ -213,7 +282,7 @@ function displayEvents(date) {
   eventsContainer.innerHTML = '';
 
   for (let i = 0; i < events.length; i++) {
-    eventsContainer.appendChild(createEventElement(events[i]));
+    eventsContainer.appendChild(createEventElement(events[i], true));
   }
 }
 
@@ -267,16 +336,23 @@ function getDateOfThePreviousMonth(date) {
 }
 
 /**
+ * Joins the event by sending the request to the server.
+ * @param {String} eventId The id of the event that the current user will join.
+ */
+function joinEvent(eventId) {
+  const params = new URLSearchParams();
+  params.append('event-id', eventId);
+
+  fetch('/joined-events', {method: 'POST', body: params});
+}
+
+/**
  * Loads the calendar associated with the current date and displays the events
  * of the current day.
  */
 function loadCalendar() {
   const currentDate = new Date();
-  const today = new Date(currentDate.getFullYear(), currentDate.getMonth(),
-      currentDate.getDate());
-
   createCalendarOfTheMonth(currentDate);
-  displayEvents(today);
 }
 
 /**
@@ -287,11 +363,11 @@ async function loadEvents() {
   const events = await response.json();
 
   events.forEach((event) => {
-    const eventStartDate = new Date(event.start);
-    const eventEndDate = new Date(event.end);
+    const eventStartDate = new Date(event.startTime);
+    const eventEndDate = new Date(event.endTime);
     const eventStartDay = new Date(eventStartDate.getFullYear(),
         eventStartDate.getMonth(), eventStartDate.getDate());
-    const eventObject = new Event(event.title, eventStartDate,
+    const eventObject = new Event(event.id, event.title, eventStartDate,
         eventEndDate);
 
     if (eventStartDay in eventsDictionary) {

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -156,7 +156,7 @@ function addButtonToGetNewMonth(buttonClass, calendarHeader, date,
 function addChatroomButton(eventOptionsElement) {
   const chatroomButton = createElement('button', 'rounded-button', 'Chatroom');
   chatroomButton.addEventListener('click', function() {
-    // TODO: redirect the user to the chatroom
+    // TODO: redirect the user to the chatroom (pull request #21)
   });
   eventOptionsElement.appendChild(chatroomButton);
 }

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -28,13 +28,13 @@ const eventsDictionary = {};
 class Event {
   /**
    * Creates a new event with the given parameters.
-   * @param {Long} id The id used to store the event in the database.
+   * @param {long} id The id used to store the event in the database.
    * @param {String} title The title of the event.
    * @param {Date} start The start date of the event.
    * @param {Date} end The end date of the event.
    */
   constructor(id, title, start, end) {
-    /** @private @const {LOng} */
+    /** @private @const {long} */
     this.id_ = id;
     /** @private @const {String} */
     this.title_ = title;
@@ -258,8 +258,7 @@ function createCalendarOfTheMonth(date) {
 }
 
 /**
- * Displays the events happening on the given date in the 'events'
- * container.
+ * Displays the events happening on the given date for which the user signed up.
  * @param {Date} date The date for which the events will be displayed.
  */
 function displayEvents(date) {
@@ -277,8 +276,8 @@ function displayEvents(date) {
 }
 
 /**
- * Displays the events from the date received and marks the element as the one
- * containing the selected day.
+ * Displays the events from the date received for which the user signed up
+ * and marks the element as the one containing the selected day.
  * @param {Date} date The date for which the events will be displayed.
  * @param {Element} dateElement The element containing the selected day.
  */
@@ -354,7 +353,7 @@ function joinEvent(eventId) {
 
 /**
  * Loads the calendar associated with the current date and displays the events
- * of the current day.
+ * of the current day for which the user signed up.
  */
 function loadCalendar() {
   const currentDate = new Date();
@@ -362,7 +361,7 @@ function loadCalendar() {
 }
 
 /**
- * Fetches events from the server and stores them in the dictionary.
+ * Fetches events for which the user signed up from the server.
  */
 async function loadEvents() {
   const response = await fetch('/joined-events');

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -72,22 +72,6 @@ function addEventsOfTheDay(date, dateElement) {
 }
 
 /**
- * Displays the evnts from the date received and marks the element as the one
- * containing the selected day.
- * @param {Date} date The date for which the events will be displayed.
- * @param {Element} dateElement The element containing the selected day.
- */
-function displayEventsAndMarkDay(date, dateElement) {
-  displayEvents(date);
-
-  const currentlySelectedDay = document.getElementById('selected-day');
-  if (currentlySelectedDay !== null) {
-    currentlySelectedDay.id = '';
-  }
-  dateElement.id = 'selected-day';
-}
-
-/**
  * Adds the days of the current month into the calendar table.
  * @param {Element} calendarTable The table that is part of the calendar.
  * @param {Date} date The date for whose month we will add the days.
@@ -178,12 +162,13 @@ function addChatroomButton(eventOptionsElement) {
 }
 
 /**
- * Adds the event options available based on the user status (if the user joins
+ * Adds the event options available based on the user status (if the user joined
  * the event or not).
  * @param {Object} event The object containing the data associated with that
  * event.
  * @param {Element} eventElement The element associated with this event.
- * @param {Boolean} hasJoined Indicates if the user has joined the event.
+ * @param {Boolean} hasJoined Indicates whether or not the user has joined
+ * the event.
  */
 function addEventOptions(event, eventElement, hasJoined) {
   const eventOptionsElement = createElement('div', '', '');
@@ -237,7 +222,8 @@ function compareEventsByStartDate(firstEvent, secondEvent) {
 /**
  * Creates the element associated with a given event.
  * @param {Object} event The event for which we will create a new element.
- * @param {Boolean} hasJoined True if the user has joined the event, false otherwise.
+ * @param {Boolean} hasJoined Indicates whether or not the user has joined
+ * the event.
  * @return {Element} The element created.
  */
 function createEventElement(event, hasJoined) {
@@ -284,6 +270,22 @@ function displayEvents(date) {
   for (let i = 0; i < events.length; i++) {
     eventsContainer.appendChild(createEventElement(events[i], true));
   }
+}
+
+/**
+ * Displays the events from the date received and marks the element as the one
+ * containing the selected day.
+ * @param {Date} date The date for which the events will be displayed.
+ * @param {Element} dateElement The element containing the selected day.
+ */
+function displayEventsAndMarkDay(date, dateElement) {
+  displayEvents(date);
+
+  const currentlySelectedDay = document.getElementById('selected-day');
+  if (currentlySelectedDay !== null) {
+    currentlySelectedDay.id = '';
+  }
+  dateElement.id = 'selected-day';
 }
 
 /**

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -65,7 +65,7 @@ function addGroupOptions(group, groupElement, isMember) {
  * @param {Element} groupElement The element associated with this group.
  */
 function addJoinGroupButton(group, groupOptionsElement, groupElement) {
-  const joinGroupButton = createElement('button', '', 'Join');
+  const joinGroupButton = createElement('button', 'rounded-button', 'Join');
 
   joinGroupButton.addEventListener('click', function() {
     joinGroup(group.id_);
@@ -113,13 +113,15 @@ function addNewGroup() {
 }
 
 /**
- * Adds a show events button through which the user can see the list of events of the group.
- * @param {Object} group The object containing the data associated with that group.
+ * Adds a show events button through which the user can see the list of events
+ * of the group.
+ * @param {Object} group The object containing the data associated with that
+ * group.
  * @param {Element} groupOptionsElement The element in which the button
  * will be inserted.
  */
 function addShowEventsButton(group, groupOptionsElement) {
-  const showEventsButton = createElement('button', '', 'Events');
+  const showEventsButton = createElement('button', 'rounded-button', 'Events');
 
   showEventsButton.addEventListener('click', function() {
     showListOfEvents(group.id_);
@@ -233,8 +235,8 @@ async function loadGroupEvents(groupId) {
   events.forEach((event) => {
     const eventStartTime = new Date(event.startTime);
     const eventEndDate = new Date(event.endTime);
-    const eventObject = new Event(event.title, eventStartTime, eventEndDate);
-    eventsContainer.appendChild(createEventElement(eventObject));
+    const eventObject = new Event(event.id, event.title, eventStartTime, eventEndDate);
+    eventsContainer.appendChild(createEventElement(eventObject, false));
   });
 }
 
@@ -270,8 +272,8 @@ function loadJoinedGroups() {
 /**
  * Fetches the groups not joined by the user and adds them to the associated container.
  */
-function loadOtherGroups() {
-  loadGroups('/groups', 'other-groups-container', false);
+function loadNotJoinedGroups() {
+  loadGroups('/groups', 'not-joined-groups-container', false);
 }
 
 /**
@@ -286,7 +288,8 @@ function openForm(formType) {
 }
 
 /**
- * Shows the events of the group as a list.
+ * Shows the events (only the ones not joined yet by the user) of the
+ * group as a list.
  * @param {long} groupId The group id.
  */
 async function showListOfEvents(groupId) {
@@ -306,4 +309,4 @@ window.closeListOfEvents = closeListOfEvents;
 window.closeForm = closeForm;
 window.openForm = openForm;
 
-export {loadJoinedGroups, loadOtherGroups};
+export {loadJoinedGroups, loadNotJoinedGroups};

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -212,7 +212,7 @@ function createGroupElement(group, isMember) {
 
 /**
  * Joins the group by sending the request to the server.
- * @param {String} groupId The id of the group that the current user will join.
+ * @param {String} groupId The id of the group that the user will join.
  */
 function joinGroup(groupId) {
   const params = new URLSearchParams();

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -27,7 +27,7 @@ class Group {
    * @param {int} year The year of study.
    */
   constructor(id, university, degree, year) {
-    /** @private @const {Long} */
+    /** @private @const {long} */
     this.id_ = id;
     /** @private @const {String} */
     this.university_ = university;
@@ -36,6 +36,46 @@ class Group {
     /** @private @const {int} */
     this.year_ = year;
   }
+}
+
+/**
+ * Adds the group options available based on the user membership (if the user
+ * is part of the group or not).
+ * @param {Object} group The object containing the data associated with that group.
+ * @param {Element} groupElement The element associated with this group.
+ * @param {Boolean} isMember Indicates if the user is a member of the group.
+ */
+function addGroupOptions(group, groupElement, isMember) {
+  const groupOptionsElement = createElement('div', 'group-options', '');
+
+  if (isMember) {
+    addShowEventsButton(group, groupOptionsElement);
+  } else {
+    addJoinGroupButton(group, groupOptionsElement, groupElement);
+  }
+
+  groupElement.appendChild(groupOptionsElement);
+}
+
+/**
+ * Adds a join button through which the user can become a member of that group.
+ * @param {Object} group The object containing the data associated with that group.
+ * @param {Element} groupOptionsElement The element in which the button
+ * will be inserted.
+ * @param {Element} groupElement The element associated with this group.
+ */
+function addJoinGroupButton(group, groupOptionsElement, groupElement) {
+  const joinGroupButton = createElement('button', '', 'Join');
+
+  joinGroupButton.addEventListener('click', function() {
+    joinGroup(group.id_);
+    groupElement.remove();
+
+    const joinedGroupsList = document.getElementById('joined-groups-container');
+    joinedGroupsList.prepend(createGroupElement(group, true));
+  });
+
+  groupOptionsElement.appendChild(joinGroupButton);
 }
 
 /**
@@ -70,6 +110,22 @@ function addNewGroup() {
   params.append('year', year);
 
   fetch('/groups', {method: 'POST', body: params});
+}
+
+/**
+ * Adds a show events button through which the user can see the list of events of the group.
+ * @param {Object} group The object containing the data associated with that group.
+ * @param {Element} groupOptionsElement The element in which the button
+ * will be inserted.
+ */
+function addShowEventsButton(group, groupOptionsElement) {
+  const showEventsButton = createElement('button', '', 'Events');
+
+  showEventsButton.addEventListener('click', function() {
+    showListOfEvents(group.id_);
+  });
+
+  groupOptionsElement.appendChild(showEventsButton);
 }
 
 /**
@@ -134,7 +190,7 @@ function createDetailsMessage(degree, year) {
  * @param {object} group The group for which we will create a new element.
  * @return {Element} The element created.
  */
-function createGroupElement(group) {
+function createGroupElement(group, isMember) {
   const groupElement = createElement('div', 'group', '');
 
   groupElement.appendChild(createElement('div', 'group-university',
@@ -142,10 +198,7 @@ function createGroupElement(group) {
   groupElement.appendChild(createElement('hr', '', ''));
   groupElement.appendChild(createElement('div', 'group-details',
       createDetailsMessage(group.degree_, group.year_)));
-
-  groupElement.addEventListener('click', function() {
-    showListOfEvents(group.id_);
-  });
+  addGroupOptions(group, groupElement, isMember);
 
   return groupElement;
 }
@@ -186,21 +239,39 @@ async function loadGroupEvents(groupId) {
 }
 
 /**
- * Fetches the groups from the server and adds them to the groups section.
+ * Fetches groups from the servlet and displays them in the given container.
+ * The function assumes the user is either part of all the groups or none at all.
+ * @param {String} servlet The servlet from which the groups will be fetched.
+ * @param {String} containerID The ID of the caontainer that will display all the groups.
+ * @param {Boolean} isMember Indicates if the user is a member of those groups or not.
  */
-function loadGroups() {
-  const groupsList = document.getElementById('groups-container');
+function loadGroups(servlet, containerID, isMember) {
+  const groupsList = document.getElementById(containerID);
   groupsList.innerHTML = '';
 
-  fetch('/groups')
+  fetch(servlet)
       .then((response) => response.json())
       .then((groups) => {
         groups.forEach((group) => {
           const groupObject = new Group(group.id, group.university,
               group.degree, group.year);
-          groupsList.appendChild(createGroupElement(groupObject));
+          groupsList.appendChild(createGroupElement(groupObject, isMember));
         });
       });
+}
+
+/**
+ * Fetches the groups joined by the user and adds them to the associated container.
+ */
+function loadJoinedGroups() {
+  loadGroups('/joined-groups', 'joined-groups-container', true);
+}
+
+/**
+ * Fetches the groups not joined by the user and adds them to the associated container.
+ */
+function loadOtherGroups() {
+  loadGroups('/groups', 'other-groups-container', false);
 }
 
 /**
@@ -235,4 +306,4 @@ window.closeListOfEvents = closeListOfEvents;
 window.closeForm = closeForm;
 window.openForm = openForm;
 
-export {loadGroups};
+export {loadJoinedGroups, loadOtherGroups};

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -43,7 +43,7 @@ class Group {
  * is part of the group or not).
  * @param {Object} group The object containing the data associated with that group.
  * @param {Element} groupElement The element associated with this group.
- * @param {Boolean} isMember Indicates if the user is a member of the group.
+ * @param {Boolean} isMember Indicates whether or not the user is a member of the group.
  */
 function addGroupOptions(group, groupElement, isMember) {
   const groupOptionsElement = createElement('div', 'group-options', '');
@@ -114,7 +114,7 @@ function addNewGroup() {
 
 /**
  * Adds a show events button through which the user can see the list of events
- * of the group.
+ * of the group that they didn't join yet.
  * @param {Object} group The object containing the data associated with that
  * group.
  * @param {Element} groupOptionsElement The element in which the button
@@ -244,8 +244,9 @@ async function loadGroupEvents(groupId) {
  * Fetches groups from the servlet and displays them in the given container.
  * The function assumes the user is either part of all the groups or none at all.
  * @param {String} servlet The servlet from which the groups will be fetched.
- * @param {String} containerID The ID of the caontainer that will display all the groups.
- * @param {Boolean} isMember Indicates if the user is a member of those groups or not.
+ * @param {String} containerID The ID of the container that will display all the groups.
+ * @param {Boolean} isMember Indicates whether or not the user is a member of
+ * those groups or not.
  */
 function loadGroups(servlet, containerID, isMember) {
   const groupsList = document.getElementById(containerID);

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -41,9 +41,11 @@ class Group {
 /**
  * Adds the group options available based on the user membership (if the user
  * is part of the group or not).
- * @param {Object} group The object containing the data associated with that group.
+ * @param {Object} group The object containing the data associated with that
+ * group.
  * @param {Element} groupElement The element associated with this group.
- * @param {Boolean} isMember Indicates whether or not the user is a member of the group.
+ * @param {Boolean} isMember Indicates whether or not the user is a member of
+ * the group.
  */
 function addGroupOptions(group, groupElement, isMember) {
   const groupOptionsElement = createElement('div', 'group-options', '');
@@ -59,7 +61,8 @@ function addGroupOptions(group, groupElement, isMember) {
 
 /**
  * Adds a join button through which the user can become a member of that group.
- * @param {Object} group The object containing the data associated with that group.
+ * @param {Object} group The object containing the data associated with that
+ * group.
  * @param {Element} groupOptionsElement The element in which the button
  * will be inserted.
  * @param {Element} groupElement The element associated with this group.
@@ -189,7 +192,9 @@ function createDetailsMessage(degree, year) {
 
 /**
  * Creates the element associated with a given group.
- * @param {object} group The group for which we will create a new element.
+ * @param {Object} group The group for which we will create a new element.
+ * @param {Boolean} isMember Indicates whether or not the user is member of
+ * the group.
  * @return {Element} The element created.
  */
 function createGroupElement(group, isMember) {
@@ -235,16 +240,19 @@ async function loadGroupEvents(groupId) {
   events.forEach((event) => {
     const eventStartTime = new Date(event.startTime);
     const eventEndDate = new Date(event.endTime);
-    const eventObject = new Event(event.id, event.title, eventStartTime, eventEndDate);
+    const eventObject = new Event(event.id, event.title, eventStartTime,
+        eventEndDate);
     eventsContainer.appendChild(createEventElement(eventObject, false));
   });
 }
 
 /**
  * Fetches groups from the servlet and displays them in the given container.
- * The function assumes the user is either part of all the groups or none at all.
+ * The function assumes the user is either part of all the groups or none at
+ * all.
  * @param {String} servlet The servlet from which the groups will be fetched.
- * @param {String} containerID The ID of the container that will display all the groups.
+ * @param {String} containerID The ID of the container that will display all
+ * the groups.
  * @param {Boolean} isMember Indicates whether or not the user is a member of
  * those groups or not.
  */
@@ -264,14 +272,16 @@ function loadGroups(servlet, containerID, isMember) {
 }
 
 /**
- * Fetches the groups joined by the user and adds them to the associated container.
+ * Fetches the groups joined by the user and adds them to the associated
+ * container.
  */
 function loadJoinedGroups() {
   loadGroups('/joined-groups', 'joined-groups-container', true);
 }
 
 /**
- * Fetches the groups not joined by the user and adds them to the associated container.
+ * Fetches the groups not joined by the user and adds them to the associated
+ * container.
  */
 function loadNotJoinedGroups() {
   loadGroups('/groups', 'not-joined-groups-container', false);

--- a/src/main/webapp/home-page-script.js
+++ b/src/main/webapp/home-page-script.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import {initClient, loadProfileData, signOut} from './script.js';
-import {loadJoinedGroups, loadOtherGroups} from './groups-script.js';
+import {loadJoinedGroups, loadNotJoinedGroups} from './groups-script.js';
 import {loadEvents, loadCalendar} from './events-script.js';
 
 /**
@@ -52,7 +52,7 @@ async function loadProfile() {
   await loadEvents();
   loadCalendar();
   loadJoinedGroups();
-  loadOtherGroups();
+  loadNotJoinedGroups();
 }
 
 /**

--- a/src/main/webapp/home-page-script.js
+++ b/src/main/webapp/home-page-script.js
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 import {initClient, loadProfileData, signOut} from './script.js';
-import {loadGroups} from './groups-script.js';
+import {loadJoinedGroups, loadOtherGroups} from './groups-script.js';
 import {loadEvents, loadCalendar} from './events-script.js';
 
 /**
@@ -51,7 +51,8 @@ async function loadProfile() {
   await loadProfileData();
   await loadEvents();
   loadCalendar();
-  loadGroups();
+  loadJoinedGroups();
+  loadOtherGroups();
 }
 
 /**

--- a/src/main/webapp/home-page-style.css
+++ b/src/main/webapp/home-page-style.css
@@ -210,6 +210,19 @@ label {
   width: 150px;
 }
 
+.rounded-button {
+  background-color: #008b8b;
+  border: none;
+  border-radius: 15px;
+  box-sizing: border-box;
+  color: white;
+  cursor: pointer;
+  font-size: 15px;
+  font-weight: bold;
+  opacity: 0.8;
+  padding: 10px;
+}
+
 .sign-out-button {
   bottom: 0;
   box-sizing: border-box;

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -46,7 +46,7 @@
           <h2>
             Discover more groups
           </h2>
-          <div id="other-groups-container">
+          <div id="not-joined-groups-container">
           </div>
           <button id="open-group-form" onclick="openForm('group')">
             Create new group

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -41,7 +41,12 @@
           <h2>
             Your groups
           </h2>
-          <div id="groups-container">
+          <div id="joined-groups-container">
+          </div>
+          <h2>
+            Discover more groups
+          </h2>
+          <div id="other-groups-container">
           </div>
           <button id="open-group-form" onclick="openForm('group')">
             Create new group


### PR DESCRIPTION
Continuation of #15 

The main scope of this pull request is to connect the front-end with the back-end functionalities of joining groups/events. 
- The groups section includes two different containers: the first one with joined groups and the second one with all the other groups already created that the user didn't join yet.
- The group element contains a join button if the user is not a member of it yet or a show events button otherwise. The show events button will display all the events associated with that group that the user didn't join yet.
- A button is associated with each event from the list mentioned before.
- Once the user has joined an event, it will be removed from the list of events not joined.
- Each event joined can be viewed from the calendar and has a button that will open the chat room.
- The calendar will automatically display the events for the current day.