### PR TITLE
Display the events joined by the user as a separate section of the list of events.

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -370,6 +370,19 @@ public class DatastoreAccess {
   }
 
   /**
+   * Gets all the events in a certain group that the user had joined already.
+   *
+   * @param groupId The id of the group.
+   * @param userId The id of the user.
+   * @return The list of events that the user had joined already.
+   */
+  public List<Event> getAllJoinedEventsFromGroup(long groupId, String userId) {
+    List<Event> events = getAllEventsFromGroup(groupId);
+    events.retainAll(getJoinedEvents(userId));
+    return events;
+  }
+
+  /**
    * Gets all the events in a certain group that the user didn't join yet.
    *
    * @param groupId The id of the group.

--- a/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
@@ -79,7 +79,10 @@ public class GroupEventsServlet extends HttpServlet {
       long start = Long.parseLong(request.getParameter(START_DATE_PARAMETER));
       long end = Long.parseLong(request.getParameter(END_DATE_PARAMETER));
 
-      datastore.addEventToGroup(groupId, title, start, end, userId.get());
+      long eventId = datastore.addEventToGroup(groupId, title, start, end, userId.get());
+      if (eventId != 0) {
+        datastore.joinEvent(userId.get(), eventId);
+      }
     } catch (NumberFormatException e) {
       throw new BadRequestException(e.getMessage());
     }

--- a/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupsServlet.java
@@ -58,7 +58,9 @@ public class GroupsServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    if (!AuthStatus.isSignedIn(request)) {
+    Optional<String> userId = AuthStatus.getUserId(request);
+
+    if (!userId.isPresent()) {
       return;
     }
 
@@ -67,7 +69,8 @@ public class GroupsServlet extends HttpServlet {
       String degree = request.getParameter(DEGREE_PARAMETER);
       int year = Integer.parseInt(request.getParameter(YEAR_PARAMETER));
 
-      datastore.addGroup(university, degree, year);
+      long groupId = datastore.addGroup(university, degree, year);
+      datastore.joinGroup(userId.get(), groupId);
     } catch (NumberFormatException e) {
       throw new BadRequestException(e.getMessage());
     }

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -27,11 +27,15 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
-/** Servlet for joining an event and listing all the events that the user joined. */
+/**
+ * Servlet for joining an event and listing all the events that the user joined from all the groups
+ * or from just one particular group specified by its id.
+ */
 @WebServlet("/joined-events")
 public class JoinedEventsServlet extends HttpServlet {
 
   private static final String EVENT_ID_PARAMETER = "event-id";
+  private static final String GROUP_ID_PARAMETER = "group-id";
   private static DatastoreAccess datastore;
 
   @Override
@@ -47,7 +51,20 @@ public class JoinedEventsServlet extends HttpServlet {
       return;
     }
 
-    List<Event> events = datastore.getJoinedEvents(userId.get());
+    List<Event> events;
+    String groupIdString = request.getParameter(GROUP_ID_PARAMETER);
+
+    if (groupIdString == null) {
+      events = datastore.getJoinedEvents(userId.get());
+    } else {
+      try {
+        long groupId = Long.parseLong(groupIdString);
+        events = datastore.getAllJoinedEventsFromGroup(groupId, userId.get());
+      } catch (NumberFormatException e) {
+        throw new BadRequestException(e.getMessage());
+      }
+    }
+
     response.setContentType("application/json;");
     response.setCharacterEncoding("UTF-8");
     Gson gson = new Gson();

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -224,8 +224,8 @@ function joinGroup(groupId) {
 /**
  * Fetches events (from the group specified by the groupId) from the servlet
  * and displays them in the given container. The hasJoined parameter can be
- * used to fetch all the events that the user has joined or all the events
- * that the user has not joined.
+ * used to fetch all the events that the user has joined or all the events that
+ * the user has not joined.
  * @param {String} servlet The servlet from which the events will be fetched.
  * @param {String} containerID The ID of the container that will display all
  * the events.

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -223,8 +223,9 @@ function joinGroup(groupId) {
 
 /**
  * Fetches events (from the group specified by the groupId) from the servlet
- * and displays them in the given container. The function assumes the user has
- * joined all the events or none at all.
+ * and displays them in the given container. The hasJoined can be used to fetch
+ * all the events that the user has joined or all the events that the user has
+ * not joined.
  * @param {String} servlet The servlet from which the events will be fetched.
  * @param {String} containerID The ID of the container that will display all
  * the events.
@@ -274,8 +275,8 @@ async function loadNotJoinedEventsFromGroup(groupId) {
 
 /**
  * Fetches groups from the servlet and displays them in the given container.
- * The function assumes the user is either part of all the groups or none at
- * all.
+ * The isMember can be used to fetch all the groups that the user has joined
+ * or all the groups that the user has not joined.
  * @param {String} servlet The servlet from which the groups will be fetched.
  * @param {String} containerID The ID of the container that will display all
  * the groups.

--- a/src/main/webapp/groups-script.js
+++ b/src/main/webapp/groups-script.js
@@ -223,9 +223,9 @@ function joinGroup(groupId) {
 
 /**
  * Fetches events (from the group specified by the groupId) from the servlet
- * and displays them in the given container. The hasJoined can be used to fetch
- * all the events that the user has joined or all the events that the user has
- * not joined.
+ * and displays them in the given container. The hasJoined parameter can be
+ * used to fetch all the events that the user has joined or all the events
+ * that the user has not joined.
  * @param {String} servlet The servlet from which the events will be fetched.
  * @param {String} containerID The ID of the container that will display all
  * the events.
@@ -275,8 +275,8 @@ async function loadNotJoinedEventsFromGroup(groupId) {
 
 /**
  * Fetches groups from the servlet and displays them in the given container.
- * The isMember can be used to fetch all the groups that the user has joined
- * or all the groups that the user has not joined.
+ * The isMember parameter can be used to fetch all the groups that the user has
+ * joined or all the groups that the user has not joined.
  * @param {String} servlet The servlet from which the groups will be fetched.
  * @param {String} containerID The ID of the container that will display all
  * the groups.

--- a/src/main/webapp/home-page.html
+++ b/src/main/webapp/home-page.html
@@ -86,7 +86,15 @@
               keyboard_backspace
             </i>
           </div>
-          <div id="group-events">
+          <h2>
+            Your events
+          </h2>
+          <div id="joined-events-container">
+          </div>
+          <h2>
+            Discover more events
+          </h2>
+          <div id="not-joined-events-container">
           </div>
           <button id="open-event-form" onclick="openForm('event')">
             Create new event


### PR DESCRIPTION
**Can't be merged before #29.**

In the current state, the list of events associated with a group only contains the events not joined by the user yet. This pull request introduces a **separation of the events in two different containers based on the user join status**. 

The main changes are:
- The loadGroupEvents function was generalised to handle both of the cases.
- The doGet method of the JoinedEventsServlet was modified such that it will retrieve all the events joined from a given group if specified. Otherwise, it will retrieve all the events joined by the user from all the groups.
- The DatastoreAccess.java class contains a new method to obtain only the events joined by the user from a given group.
