### PR TITLE
Events retrieving

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -399,6 +399,7 @@ public class DatastoreAccess {
   /**
    * Gets all the events joined by the user whose start date is in the interval [beginningDate,
    * endingDate).
+   *
    * @param beginningDate The inclusive lower bound value of the interval used to filter the events
    *     by their start date.
    * @param endingDate The exclusive upper bound value of the interval used to filter the events by

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /** API class for methods that access and operate on the datastore database. */
 public class DatastoreAccess {
@@ -374,5 +375,36 @@ public class DatastoreAccess {
     List<Event> events = getAllEventsFromGroup(groupId);
     events.removeAll(getJoinedEvents(userId));
     return events;
+  }
+
+  /**
+   * Gets all the events joined by the user whose start date is in the interval [beginningDate, endingDate).
+   * @param beginningDate The inclusive lower bound value of the interval used to filter the events
+   * by their start date.
+   * @param endingDate The exclusive upper bound value of the interval used to filter the events by
+   * their start date.
+   * @param userId The id of the user.
+   * @return A list of the events joined by the user whose start date is in the interval
+   * [beginningDate, endingDate).
+   */
+  public List<Event> getJoinedEventsThatStartBetweenDates(long beginningDate, long endingDate, String userId) {
+    List<Event> joinedEvents = getJoinedEvents(userId);
+    Query query = new Query(EventEntity.KIND.getLabel());
+    query.setFilter(
+        new CompositeFilter(
+            CompositeFilterOperator.AND,
+            Arrays.asList(
+                new FilterPredicate(
+                    EventEntity.START_PROPERTY.getLabel(), FilterOperator.GREATER_THAN_OR_EQUAL, beginningDate),
+                new FilterPredicate(
+                    EventEntity.START_PROPERTY.getLabel(), FilterOperator.LESS_THAN, endingDate))));
+    return StreamSupport.stream(datastore.prepare(query).asIterable().spliterator(), false)
+        .map(
+            entity ->
+                Event.createEventFromEntity(entity))
+        .filter(
+            event ->
+                joinedEvents.contains(event))
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -397,16 +397,18 @@ public class DatastoreAccess {
   }
 
   /**
-   * Gets all the events joined by the user whose start date is in the interval [beginningDate, endingDate).
+   * Gets all the events joined by the user whose start date is in the interval [beginningDate,
+   * endingDate).
    * @param beginningDate The inclusive lower bound value of the interval used to filter the events
-   * by their start date.
+   *     by their start date.
    * @param endingDate The exclusive upper bound value of the interval used to filter the events by
-   * their start date.
+   *     their start date.
    * @param userId The id of the user.
    * @return A list of the events joined by the user whose start date is in the interval
-   * [beginningDate, endingDate).
+   *     [beginningDate, endingDate).
    */
-  public List<Event> getJoinedEventsThatStartBetweenDates(long beginningDate, long endingDate, String userId) {
+  public List<Event> getJoinedEventsThatStartBetweenDates(
+      long beginningDate, long endingDate, String userId) {
     List<Event> joinedEvents = getJoinedEvents(userId);
     Query query = new Query(EventEntity.KIND.getLabel());
     query.setFilter(
@@ -414,16 +416,16 @@ public class DatastoreAccess {
             CompositeFilterOperator.AND,
             Arrays.asList(
                 new FilterPredicate(
-                    EventEntity.START_PROPERTY.getLabel(), FilterOperator.GREATER_THAN_OR_EQUAL, beginningDate),
+                    EventEntity.START_PROPERTY.getLabel(),
+                    FilterOperator.GREATER_THAN_OR_EQUAL,
+                    beginningDate),
                 new FilterPredicate(
-                    EventEntity.START_PROPERTY.getLabel(), FilterOperator.LESS_THAN, endingDate))));
+                    EventEntity.START_PROPERTY.getLabel(),
+                    FilterOperator.LESS_THAN,
+                    endingDate))));
     return StreamSupport.stream(datastore.prepare(query).asIterable().spliterator(), false)
-        .map(
-            entity ->
-                Event.createEventFromEntity(entity))
-        .filter(
-            event ->
-                joinedEvents.contains(event))
+        .map(entity -> Event.createEventFromEntity(entity))
+        .filter(event -> joinedEvents.contains(event))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -420,9 +420,7 @@ public class DatastoreAccess {
                     FilterOperator.GREATER_THAN_OR_EQUAL,
                     beginningDate),
                 new FilterPredicate(
-                    EventEntity.START_PROPERTY.getLabel(),
-                    FilterOperator.LESS_THAN,
-                    endingDate))));
+                    EventEntity.START_PROPERTY.getLabel(), FilterOperator.LESS_THAN, endingDate))));
     return StreamSupport.stream(datastore.prepare(query).asIterable().spliterator(), false)
         .map(entity -> Event.createEventFromEntity(entity))
         .filter(event -> joinedEvents.contains(event))

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -28,8 +28,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
 /**
- * Servlet for joining an event and listing all the events that the user joined from all the groups
- * or from just one particular group specified by its id.
+ * Servlet for joining an event and listing all the events that satisfy a specific criteria:
+ * - All the events joined by the user that are associated with a given group.
+ * - All the events joined by the user whose start date is between two dates received.
  */
 @WebServlet("/joined-events")
 public class JoinedEventsServlet extends HttpServlet {

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -28,9 +28,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
 /**
- * Servlet for joining an event and listing all the events that satisfy a specific criteria (all
- * the events joined by the user that are associated with a given group, all the events joined by
- * the user whose start date is between two dates received).
+ * Servlet for joining an event and listing all the events that satisfy a specific criteria (all the
+ * events joined by the user that are associated with a given group, all the events joined by the
+ * user whose start date is between two dates received).
  */
 @WebServlet("/joined-events")
 public class JoinedEventsServlet extends HttpServlet {

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -19,6 +19,7 @@ import com.google.lecturechat.data.AuthStatus;
 import com.google.lecturechat.data.DatastoreAccess;
 import com.google.lecturechat.data.Event;
 import java.io.IOException;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
@@ -32,6 +33,8 @@ import javax.ws.rs.BadRequestException;
 public class JoinedEventsServlet extends HttpServlet {
 
   private static final String EVENT_ID_PARAMETER = "event-id";
+  private static final String BEGINNING_DATE_PARAMETER = "beginning-date";
+  private static final String ENDING_DATE_PARAMETER = "ending-date";
   private static DatastoreAccess datastore;
 
   @Override
@@ -47,7 +50,21 @@ public class JoinedEventsServlet extends HttpServlet {
       return;
     }
 
-    List<Event> events = datastore.getJoinedEvents(userId.get());
+    List<Event> events;
+    String beginningDate = request.getParameter(BEGINNING_DATE_PARAMETER);
+    String endingDate = request.getParameter(ENDING_DATE_PARAMETER);
+
+    if (beginningDate == null || endingDate == null) {
+      return;
+    }
+
+    try {
+      events = datastore.getJoinedEventsThatStartBetweenDates(Long.parseLong(beginningDate),
+          Long.parseLong(endingDate), userId.get());
+    } catch (NumberFormatException e) {
+      throw new BadRequestException(e.getMessage());
+    }
+
     response.setContentType("application/json;");
     response.setCharacterEncoding("UTF-8");
     Gson gson = new Gson();

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -28,9 +28,9 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.BadRequestException;
 
 /**
- * Servlet for joining an event and listing all the events that satisfy a specific criteria:
- * - All the events joined by the user that are associated with a given group.
- * - All the events joined by the user whose start date is between two dates received.
+ * Servlet for joining an event and listing all the events that satisfy a specific criteria (all
+ * the events joined by the user that are associated with a given group, all the events joined by
+ * the user whose start date is between two dates received).
  */
 @WebServlet("/joined-events")
 public class JoinedEventsServlet extends HttpServlet {

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -19,7 +19,6 @@ import com.google.lecturechat.data.AuthStatus;
 import com.google.lecturechat.data.DatastoreAccess;
 import com.google.lecturechat.data.Event;
 import java.io.IOException;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Optional;
 import javax.servlet.annotation.WebServlet;

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -66,8 +66,9 @@ public class JoinedEventsServlet extends HttpServlet {
         if (beginningDate == null || endingDate == null) {
           return;
         }
-        events = datastore.getJoinedEventsThatStartBetweenDates(
-            Long.parseLong(beginningDate), Long.parseLong(endingDate), userId.get());
+        events =
+            datastore.getJoinedEventsThatStartBetweenDates(
+                Long.parseLong(beginningDate), Long.parseLong(endingDate), userId.get());
       }
     } catch (NumberFormatException e) {
       throw new BadRequestException(e.getMessage());

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -57,27 +57,21 @@ public class JoinedEventsServlet extends HttpServlet {
     List<Event> events;
     String groupId = request.getParameter(GROUP_ID_PARAMETER);
 
-    if (groupId == null) {
-      events = datastore.getJoinedEvents(userId.get());
-      String beginningDate = request.getParameter(BEGINNING_DATE_PARAMETER);
-      String endingDate = request.getParameter(ENDING_DATE_PARAMETER);
+    try {
+      if (groupId != null) {
+        events = datastore.getAllJoinedEventsFromGroup(Long.parseLong(groupId),userId.get());
+      } else {
+        String beginningDate = request.getParameter(BEGINNING_DATE_PARAMETER);
+        String endingDate = request.getParameter(ENDING_DATE_PARAMETER);
 
-      if (beginningDate == null || endingDate == null) {
-        return;
-      }
-
-      try {
+        if (beginningDate == null || endingDate == null) {
+          return;
+        }
         events = datastore.getJoinedEventsThatStartBetweenDates(Long.parseLong(beginningDate),
             Long.parseLong(endingDate), userId.get());
-      } catch (NumberFormatException e) {
-        throw new BadRequestException(e.getMessage());
       }
-    } else {
-      try {
-        events = datastore.getAllJoinedEventsFromGroup(Long.parseLong(groupId), userId.get());
-      } catch (NumberFormatException e) {
-        throw new BadRequestException(e.getMessage());
-      }
+    } catch (NumberFormatException e) {
+      throw new BadRequestException(e.getMessage());
     }
 
     response.setContentType("application/json;");

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -58,7 +58,7 @@ public class JoinedEventsServlet extends HttpServlet {
 
     try {
       if (groupId != null) {
-        events = datastore.getAllJoinedEventsFromGroup(Long.parseLong(groupId),userId.get());
+        events = datastore.getAllJoinedEventsFromGroup(Long.parseLong(groupId), userId.get());
       } else {
         String beginningDate = request.getParameter(BEGINNING_DATE_PARAMETER);
         String endingDate = request.getParameter(ENDING_DATE_PARAMETER);
@@ -66,8 +66,8 @@ public class JoinedEventsServlet extends HttpServlet {
         if (beginningDate == null || endingDate == null) {
           return;
         }
-        events = datastore.getJoinedEventsThatStartBetweenDates(Long.parseLong(beginningDate),
-            Long.parseLong(endingDate), userId.get());
+        events = datastore.getJoinedEventsThatStartBetweenDates(
+            Long.parseLong(beginningDate), Long.parseLong(endingDate), userId.get());
       }
     } catch (NumberFormatException e) {
       throw new BadRequestException(e.getMessage());

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -199,7 +199,6 @@ function addJoinEventButton(eventId, eventOptionsElement, eventElement) {
   joinEventButton.addEventListener('click', async function() {
     await joinEvent(eventId);
     eventElement.remove();
-    await loadEvents();
     loadCalendar();
   });
   eventOptionsElement.appendChild(joinEventButton);
@@ -251,7 +250,7 @@ function createEventElement(event, hasJoined) {
  * @param {Date} date The date for which we want to display the calendar.
  */
 async function createCalendarOfTheMonth(date) {
-  let eventsDictionary = await loadEvents(date);
+  const eventsDictionary = await loadEvents(date);
 
   const calendarContainer = document.getElementById('calendar');
   const calendarTable = createElement('table', 'calendar-table', '');
@@ -417,4 +416,4 @@ function loadNewMonth(date, functionToCreateNewMonth) {
   createCalendarOfTheMonth(newMonthDate);
 }
 
-export {createEventElement, Event, loadEvents, loadCalendar};
+export {createEventElement, Event, loadCalendar};

--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -47,6 +47,8 @@ class Event {
  * displayed by default.
  * @param {Date} date The date for which the events will be added.
  * @param {Element} dateElement The element in which the events will be added.
+ * @param {Object} eventsDictionary A dictionary that contains the events that
+ * start in the given month.
  */
 function addEventsOfTheDay(date, dateElement, eventsDictionary) {
   const currentDate = new Date();
@@ -72,6 +74,8 @@ function addEventsOfTheDay(date, dateElement, eventsDictionary) {
  * Adds the days of the current month into the calendar table.
  * @param {Element} calendarTable The table that is part of the calendar.
  * @param {Date} date The date for whose month we will add the days.
+ * @param {Object} eventsDictionary A dictionary that contains the events that
+ * start in the given month.
  */
 function addDaysOfTheMonth(calendarTable, date, eventsDictionary) {
   const year = date.getFullYear();
@@ -256,6 +260,8 @@ async function createCalendarOfTheMonth(date) {
 /**
  * Displays the events happening on the given date for which the user signed up.
  * @param {Date} date The date for which the events will be displayed.
+ * @param {Object} eventsDictionary A dictionary that contains the events that
+ * start in the given month.
  */
 function displayEvents(date, eventsDictionary) {
   const events = eventsDictionary[date];
@@ -276,6 +282,8 @@ function displayEvents(date, eventsDictionary) {
  * and marks the element as the one containing the selected day.
  * @param {Date} date The date for which the events will be displayed.
  * @param {Element} dateElement The element containing the selected day.
+ * @param {Object} eventsDictionary A dictionary that contains the events that
+ * start in the given month.
  */
 function displayEventsAndMarkDay(date, dateElement, eventsDictionary) {
   displayEvents(date, eventsDictionary);
@@ -355,12 +363,16 @@ function loadCalendar() {
 }
 
 /**
- * Fetches events for which the user signed up from the server.
+ * Fetches events joined by the user that start in the month of the date
+ * received.
+ * @param {Date} date The date relative to whose month the events will be
+ * retrieved.
  */
 async function loadEvents(date) {
   const url = new URL('/joined-events', window.location.origin);
   const params = new URLSearchParams();
-  params.append('beginning-date', new Date(date.getFullYear(), date.getMonth()).getTime());
+  params.append('beginning-date', new Date(date.getFullYear(),
+      date.getMonth()).getTime());
   params.append('ending-date', getDateOfTheNextMonth(date).getTime());
   url.search = params;
 

--- a/src/main/webapp/home-page-script.js
+++ b/src/main/webapp/home-page-script.js
@@ -16,7 +16,7 @@
 
 import {initClient, loadProfileData, signOut} from './script.js';
 import {loadJoinedGroups, loadNotJoinedGroups} from './groups-script.js';
-import {loadEvents, loadCalendar} from './events-script.js';
+import {loadCalendar} from './events-script.js';
 
 /**
  * Gets the section ID from the option element.

--- a/src/main/webapp/home-page-script.js
+++ b/src/main/webapp/home-page-script.js
@@ -49,7 +49,6 @@ function loadHomeClient() {
  */
 async function loadProfile() {
   await loadProfileData();
-  await loadEvents();
   loadCalendar();
   loadJoinedGroups();
   loadNotJoinedGroups();


### PR DESCRIPTION
This pull request focuses on getting the **events** joined by the user **that start between two dates instead of** getting **all the events** that the user has joined **no matter their start date**. This is really useful when creating the calendar because we only display **one month at once** and we don't need all the events. In this way, we can get the other events afterwards if needed.

In order to do that, I adapted the loadEvents function to only get the events joined by the user that start in the month of the date received. 

The events are fetched from the JoinedEventsServlet which now has the following functionalities:
- Joins an event on behalf of the user.
- Gets only some of the events joined by the user:
  - Only the events associated with a group specified by its ID.
  - Only the events that start between two dates received (if the dates have been specified).
  - No events otherwise.

I excluded the option to get all the events joined by the user since we don't need it at the moment. However, it can be later added since the servlet can be extended to get **all the events that satisfy a specific criteria.**