### PR TITLE
Additional unit tests for datastore access methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,42 @@
            <executable>${project.basedir}/src/test/javascript/jasmine_setup.sh</executable>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>0.8.3</version>
+          <executions>
+            <execution>
+             <id>coverage-initialize</id>
+              <goals>
+                <goal>prepare-agent</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>coverage-report</id>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>report</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>coverage-check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <rule>
+                    <excludes>
+                      <exclude>com.google.lecturechat.data.Event</exclude>
+                      <exclude>com.google.lecturechat.data.Group</exclude>
+                    </excludes>
+                  </rule>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -271,8 +271,6 @@ public class DatastoreAccess {
       if (entitiesIds == null) {
         entitiesIds = new ArrayList<>();
       }
-      // TODO: The classes will be later modified such that the groupsIds and eventsIds
-      // will be stored as sets instead of lists.
       if (!entitiesIds.contains(entityId)) {
         entitiesIds.add(entityId);
       }

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -218,7 +218,7 @@ public class DatastoreAccess {
    * @param groupId The id of the group.
    * @return The list of events.
    */
-  private List<Event> getAllEventsFromGroup(long groupId) {
+  public List<Event> getAllEventsFromGroup(long groupId) {
     Entity groupEntity = getEntityById(GroupEntity.KIND.getLabel(), groupId);
     List<Long> eventIds =
         (ArrayList) (groupEntity.getProperty(GroupEntity.EVENTS_PROPERTY.getLabel()));

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -177,8 +177,8 @@ public class DatastoreAccess {
    */
   public long addEventToGroup(
       long groupId, String title, long startTime, long endTime, String creator) {
-    TransactionOptions options = TransactionOptions.Builder.withXG(true);
-    Transaction transaction = datastore.beginTransaction(options);
+    // Create cross-group transaction to make operations on both entity types atomic.
+    Transaction transaction = datastore.beginTransaction(TransactionOptions.Builder.withXG(true));
     long eventId = 0;
 
     try {
@@ -218,7 +218,7 @@ public class DatastoreAccess {
    * @param groupId The id of the group.
    * @return The list of events.
    */
-  public List<Event> getAllEventsFromGroup(long groupId) {
+  List<Event> getAllEventsFromGroup(long groupId) {
     Entity groupEntity = getEntityById(GroupEntity.KIND.getLabel(), groupId);
     List<Long> eventIds =
         (ArrayList) (groupEntity.getProperty(GroupEntity.EVENTS_PROPERTY.getLabel()));

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -37,17 +37,17 @@ public final class DatastoreAccessTest {
   private DatastoreService service;
 
   // Parameters for arranging.
-  private final String UNIVERSITY_A = "A";
-  private final String UNIVERSITY_B = "B";
-  private final String UNIVERSITY_C = "C";
-  private final String DEGREE = "A";
+  private final String UNIVERSITY_A = "Uni A";
+  private final String UNIVERSITY_B = "Uni B";
+  private final String UNIVERSITY_C = "Uni C";
+  private final String DEGREE = "Degree A";
   private final int YEAR = 1;
-  private final String EVENT_TITLE_A = "A";
-  private final String EVENT_CREATOR = "A";
+  private final String EVENT_TITLE_A = "Event A";
+  private final String EVENT_CREATOR = "Creator A";
   private final long START_TIME = 0;
   private final long END_TIME = 0;
-  private final String USER_ID = "A";
-  private final String USER_NAME = "A";
+  private final String USER_ID = "User Id A";
+  private final String USER_NAME = "User Name A";
 
   // Constants since we don't have access to the constants files here.
   private final String groupEntityLabel = "Group";

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -21,7 +21,6 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -43,6 +43,8 @@ public final class DatastoreAccessTest {
   private final String DEGREE = "Degree A";
   private final int YEAR = 1;
   private final String EVENT_TITLE_A = "Event A";
+  private final String EVENT_TITLE_B = "Event B";
+  private final String EVENT_TITLE_C = "Event C";
   private final String EVENT_CREATOR = "Creator A";
   private final long START_TIME = 0;
   private final long END_TIME = 0;
@@ -144,6 +146,24 @@ public final class DatastoreAccessTest {
 
     List<Group> joined = datastore.getJoinedGroups(USER_ID);
     List<Group> notJoined = datastore.getNotJoinedGroups(USER_ID);
+
+    assertEquals(2, joined.size());
+    assertEquals(1, notJoined.size());
+  }
+
+  @Test
+  public void getCorrectNumberOfJoinedAndNotJoinedEvents() {
+    long groupId = datastore.addGroup(UNIVERSITY_A, DEGREE, YEAR);
+    long eventA = datastore.addEventToGroup(groupId, EVENT_TITLE_A, START_TIME, END_TIME, EVENT_CREATOR);
+    long eventB = datastore.addEventToGroup(groupId, EVENT_TITLE_B, START_TIME, END_TIME, EVENT_CREATOR);
+    long eventC = datastore.addEventToGroup(groupId, EVENT_TITLE_C, START_TIME, END_TIME, EVENT_CREATOR);
+    datastore.addUser(USER_ID, USER_NAME);
+    datastore.joinGroup(USER_ID, groupId);
+    datastore.joinEvent(USER_ID, eventA);
+    datastore.joinEvent(USER_ID, eventB);
+
+    List<Event> joined = datastore.getAllJoinedEventsFromGroup(groupId, USER_ID);
+    List<Event> notJoined = datastore.getAllNotJoinedEventsFromGroup(groupId, USER_ID);
 
     assertEquals(2, joined.size());
     assertEquals(1, notJoined.size());

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -154,9 +154,12 @@ public final class DatastoreAccessTest {
   @Test
   public void getCorrectNumberOfJoinedAndNotJoinedEvents() {
     long groupId = datastore.addGroup(UNIVERSITY_A, DEGREE, YEAR);
-    long eventA = datastore.addEventToGroup(groupId, EVENT_TITLE_A, START_TIME, END_TIME, EVENT_CREATOR);
-    long eventB = datastore.addEventToGroup(groupId, EVENT_TITLE_B, START_TIME, END_TIME, EVENT_CREATOR);
-    long eventC = datastore.addEventToGroup(groupId, EVENT_TITLE_C, START_TIME, END_TIME, EVENT_CREATOR);
+    long eventA =
+        datastore.addEventToGroup(groupId, EVENT_TITLE_A, START_TIME, END_TIME, EVENT_CREATOR);
+    long eventB =
+        datastore.addEventToGroup(groupId, EVENT_TITLE_B, START_TIME, END_TIME, EVENT_CREATOR);
+    long eventC =
+        datastore.addEventToGroup(groupId, EVENT_TITLE_C, START_TIME, END_TIME, EVENT_CREATOR);
     datastore.addUser(USER_ID, USER_NAME);
     datastore.joinGroup(USER_ID, groupId);
     datastore.joinEvent(USER_ID, eventA);

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -32,6 +32,7 @@ import org.junit.runners.JUnit4;
 public final class DatastoreAccessTest {
 
   private final String groupEntityLabel = "Group";
+  private final String eventEntityLable = "Event";
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
   private DatastoreAccess datastore;
@@ -93,5 +94,23 @@ public final class DatastoreAccessTest {
     List<Group> groups = datastore.getAllGroups();
 
     assertEquals(2, groups.size());
+  }
+
+  @Test
+  public void addEventAddsExactlyOneEvent() {
+    String university = "A";
+    String degree = "B";
+    int year = 1;
+    datastore.addGroup(university, degree, year);
+    List<Group> groups = datastore.getAllGroups();
+    long groupId = groups.get(0).getId();
+    String title = "A";
+    String creator = "A";
+    long startTime = 0;
+    long endTime = 0;
+
+    datastore.addEventToGroup(groupId, title, startTime, endTime, creator);
+
+    assertEquals(1, service.prepare(new Query(eventEntityLable)).countEntities());
   }
 }


### PR DESCRIPTION
Main change: some additional unit tests for most methods in `DatastoreAccess` as well as some changes to the existing ones.

Also integrated the Jacoco Plugin to get test coverage. To see the coverage report, run `mvn verify`, then navigate to `target/site/jacoco/index.html` and open as window. For example, the current report (76% line coverage in general):

![Screenshot 2020-09-08 at 11 07 28 PM](https://user-images.githubusercontent.com/21975430/92528523-37162300-f229-11ea-86a8-ec8ae797aab5.png)

Tests related to messages will be added once issue #22 is implemented, and some tests for joining events are also still missing (edit: added test for joining events, raising coverage to 87%).

As an additional bug fix, `addEventToGroup` now uses a cross-group transaction instead of multiple transaction to avoid events being added to the database without being associated with a group if one of the transactions fails.