### PR TITLE
Fix return statement of the getStartOfToday function

### DIFF
--- a/src/main/webapp/events-script.js
+++ b/src/main/webapp/events-script.js
@@ -49,7 +49,9 @@ class Event {
  * @return {Date} The start of today.
  */
 function getStartOfToday() {
-  return (new Date()).setHours(0, 0, 0, 0);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
 }
 
 /**


### PR DESCRIPTION
The [setHours](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours) function doesn't return the modified date, but the number of milliseconds since epoch time until the updated Date. I changed the function to return the date instead of the number of milliseconds.