### PR TITLE
Message testing and indexing

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -459,19 +459,11 @@ public class DatastoreAccess {
    */
   public void addMessage(long eventId, String content, String author) {
     long timestamp = System.currentTimeMillis();
-    Transaction transaction = datastore.beginTransaction();
-    try {
-      Entity messageEntity = new Entity(MessageEntity.KIND.getLabel());
-      messageEntity.setProperty(MessageEntity.CONTENT_PROPERTY.getLabel(), content);
-      messageEntity.setProperty(MessageEntity.TIMESTAMP_PROPERTY.getLabel(), timestamp);
-      messageEntity.setProperty(MessageEntity.AUTHOR_PROPERTY.getLabel(), author);
-      messageEntity.setProperty(MessageEntity.EVENT_PROPERTY.getLabel(), eventId);
-      datastore.put(messageEntity);
-      transaction.commit();
-    } finally {
-      if (transaction.isActive()) {
-        transaction.rollback();
-      }
-    }
+    Entity messageEntity = new Entity(MessageEntity.KIND.getLabel());
+    messageEntity.setProperty(MessageEntity.CONTENT_PROPERTY.getLabel(), content);
+    messageEntity.setProperty(MessageEntity.TIMESTAMP_PROPERTY.getLabel(), timestamp);
+    messageEntity.setProperty(MessageEntity.AUTHOR_PROPERTY.getLabel(), author);
+    messageEntity.setProperty(MessageEntity.EVENT_PROPERTY.getLabel(), eventId);
+    datastore.put(messageEntity);
   }
 }

--- a/src/main/webapp/WEB-INF/index.yaml
+++ b/src/main/webapp/WEB-INF/index.yaml
@@ -1,0 +1,6 @@
+indexes:
+
+  - kind: Message 
+    properties:
+      - name: event
+      - name: timestamp

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -50,11 +50,13 @@ public final class DatastoreAccessTest {
   private final long END_TIME = 0;
   private final String USER_ID = "User Id A";
   private final String USER_NAME = "User Name A";
+  private final String MESSAGE_CONTENT = "Message A";
 
   // Constants since we don't have access to the constants files here.
   private final String groupEntityLabel = "Group";
   private final String eventEntityLabel = "Event";
   private final String userEntityLabel = "User";
+  private final String messageEntityLabel = "Message";
 
   @Before
   public void setUp() {
@@ -170,5 +172,29 @@ public final class DatastoreAccessTest {
 
     assertEquals(2, joined.size());
     assertEquals(1, notJoined.size());
+  }
+
+  @Test
+  public void addAndRetrieveCorrectNumberOfMessages() {
+    long eventId = 123L;
+    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+
+    List<Message> messages = datastore.getMessagesFromEvent(eventId, 20);
+
+    assertEquals(3, service.prepare(new Query(messageEntityLabel)).countEntities());
+    assertEquals(3, messages.size());
+  }
+
+  @Test
+  public void addAndRetrieveCorrectNumberOfMessagesWithLimit() {
+    long eventId = 123L;
+    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+
+    List<Message> messages = datastore.getMessagesFromEvent(eventId, 1);
+
+    assertEquals(1, messages.size());
   }
 }


### PR DESCRIPTION
Adds multiple small changes:
- Remove transaction from single operation that should be atomic by default
- Add `index.yaml` for messages since otherwise querying for messages doesn't work in deployment
- Add basic unit tests for messages, current test status for `DatastoreAccess` is now:
![Screenshot 2020-09-14 at 10 36 26 AM](https://user-images.githubusercontent.com/21975430/93063456-95526400-f676-11ea-85f9-e23370414bec.png)
