### PR TITLE
Hover style only for the group options

### DIFF
--- a/src/main/webapp/home-page-style.css
+++ b/src/main/webapp/home-page-style.css
@@ -94,10 +94,6 @@ body {
   justify-content: space-between;
 }
 
-.group:hover {
-  cursor: pointer;
-}
-
 #group-form,
 #event-form {
   background-color: #008b8b;
@@ -240,6 +236,10 @@ label {
   font-weight: bold;
   opacity: 0.8;
   padding: 10px;
+}
+
+.rounded-button:hover {
+  cursor: pointer;
 }
 
 .sign-out-button {


### PR DESCRIPTION
The whole group element shouldn't be clickable and only the group options should be (the group options have the class "rounded-button").