### PR TITLE
Restrict user access to the events of a group

### DIFF
--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -516,7 +516,7 @@ public class DatastoreAccess {
    * @param propertyName The name of the property that could contain the user id.
    * @return True if the user is part of the property.
    */
-  public boolean isPartOfEntity(
+  private boolean isPartOfEntity(
       String userId, long entityId, String entityKind, String propertyName) {
     Entity entity = getEntityById(entityKind, entityId);
     List<String> usersIds = (ArrayList) (entity.getProperty(propertyName));

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -321,7 +321,8 @@ public class DatastoreAccess {
   }
 
   /**
-   * Joins the given group by adding the group id to the user's list of groups.
+   * Joins the given group by adding the group id to the user's list of groups. The list of
+   * students associated with the group should also be updated by including the new user.
    *
    * @param userId The id of the user that joins the group.
    * @param groupId The id of the group that the user joined.
@@ -333,7 +334,8 @@ public class DatastoreAccess {
   }
 
   /**
-   * Joins the given event by adding the event id to the user's list of events.
+   * Joins the given event by adding the event id to the user's list of events. The list of
+   * attendees associated with the event should also be updated by including the new user.
    *
    * @param userId The id of the user that joins the event.
    * @param eventId The id of the event that the user joined.

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -533,6 +533,9 @@ public class DatastoreAccess {
   }
 
   /**
+   * TODO: It will be later used in a different pull request to restrict the users access to the
+   * chat rooms. Implemented now since it uses the same logic as the isMemberOfGroup function.
+   *
    * Checks if the user is an attendee of the specified event.
    *
    * @param userId The id of the user.

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -73,7 +73,8 @@ public class DatastoreAccess {
         newGroupEntity.setProperty(GroupEntity.UNIVERSITY_PROPERTY.getLabel(), university);
         newGroupEntity.setProperty(GroupEntity.DEGREE_PROPERTY.getLabel(), degree);
         newGroupEntity.setProperty(GroupEntity.YEAR_PROPERTY.getLabel(), year);
-        newGroupEntity.setProperty(GroupEntity.STUDENTS_PROPERTY.getLabel(), new ArrayList<String>());
+        newGroupEntity.setProperty(
+            GroupEntity.STUDENTS_PROPERTY.getLabel(), new ArrayList<String>());
         newGroupEntity.setProperty(GroupEntity.EVENTS_PROPERTY.getLabel(), new ArrayList<Long>());
         datastore.put(newGroupEntity);
         groupEntity = Optional.of(newGroupEntity);
@@ -289,8 +290,8 @@ public class DatastoreAccess {
   }
 
   /**
-   * Adds the user to the list of users of the entity with the given id and kind. The list of
-   * users ids is associated with the property that has the name propertyName.
+   * Adds the user to the list of users of the entity with the given id and kind. The list of users
+   * ids is associated with the property that has the name propertyName.
    *
    * @param userId The id of the user that will be added to the entity.
    * @param entityId The id of the entity to which the user will be added.
@@ -321,16 +322,16 @@ public class DatastoreAccess {
   }
 
   /**
-   * Joins the given group by adding the group id to the user's list of groups. The list of
-   * students associated with the group should also be updated by including the new user.
+   * Joins the given group by adding the group id to the user's list of groups. The list of students
+   * associated with the group should also be updated by including the new user.
    *
    * @param userId The id of the user that joins the group.
    * @param groupId The id of the group that the user joined.
    */
   public void joinGroup(String userId, long groupId) {
     joinEntity(userId, groupId, UserEntity.GROUPS_PROPERTY.getLabel());
-    addUserToEntity(userId, groupId, GroupEntity.KIND.getLabel(),
-      GroupEntity.STUDENTS_PROPERTY.getLabel());
+    addUserToEntity(
+        userId, groupId, GroupEntity.KIND.getLabel(), GroupEntity.STUDENTS_PROPERTY.getLabel());
   }
 
   /**
@@ -342,8 +343,8 @@ public class DatastoreAccess {
    */
   public void joinEvent(String userId, long eventId) {
     joinEntity(userId, eventId, UserEntity.EVENTS_PROPERTY.getLabel());
-    addUserToEntity(userId, eventId, EventEntity.KIND.getLabel(),
-      EventEntity.ATTENDEES_PROPERTY.getLabel());
+    addUserToEntity(
+        userId, eventId, EventEntity.KIND.getLabel(), EventEntity.ATTENDEES_PROPERTY.getLabel());
   }
 
   /**
@@ -515,8 +516,8 @@ public class DatastoreAccess {
    * @param propertyName The name of the property that could contain the user id.
    * @return True if the user is part of the property.
    */
-  public boolean isPartOfEntity(String userId, long entityId, String entityKind,
-      String propertyName) {
+  public boolean isPartOfEntity(
+      String userId, long entityId, String entityKind, String propertyName) {
     Entity entity = getEntityById(entityKind, entityId);
     List<String> usersIds = (ArrayList) (entity.getProperty(propertyName));
     return (usersIds != null) && usersIds.contains(userId);
@@ -530,14 +531,13 @@ public class DatastoreAccess {
    * @return True if the user is a member of the group.
    */
   public boolean isMemberOfGroup(String userId, long groupId) {
-    return isPartOfEntity(userId, groupId, GroupEntity.KIND.getLabel(),
-      GroupEntity.STUDENTS_PROPERTY.getLabel());
+    return isPartOfEntity(
+        userId, groupId, GroupEntity.KIND.getLabel(), GroupEntity.STUDENTS_PROPERTY.getLabel());
   }
 
   /**
    * TODO: It will be later used in a different pull request to restrict the users access to the
    * chat rooms. Implemented now since it uses the same logic as the isMemberOfGroup function.
-   *
    * Checks if the user is an attendee of the specified event.
    *
    * @param userId The id of the user.
@@ -545,7 +545,7 @@ public class DatastoreAccess {
    * @return True if the user is an attendee of the event.
    */
   public boolean isAttendeeOfEvent(String userId, long eventId) {
-    return isPartOfEntity(userId, eventId, EventEntity.KIND.getLabel(),
-      EventEntity.ATTENDEES_PROPERTY.getLabel());
+    return isPartOfEntity(
+        userId, eventId, EventEntity.KIND.getLabel(), EventEntity.ATTENDEES_PROPERTY.getLabel());
   }
 }

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -502,4 +502,45 @@ public class DatastoreAccess {
     messageEntity.setProperty(MessageEntity.EVENT_PROPERTY.getLabel(), eventId);
     datastore.put(messageEntity);
   }
+
+  /**
+   * Checks if the user is part of the given property associated with the entity identified by its
+   * type and its id.
+   *
+   * @param userId The id of the user.
+   * @param entityId The id of the entity.
+   * @param entityKind The entity kind label (e.g. group, event).
+   * @param propertyName The name of the property that could contain the user id.
+   * @return True if the user is part of the property.
+   */
+  public boolean isPartOfEntity(String userId, long entityId, String entityKind,
+      String propertyName) {
+    Entity entity = getEntityById(entityKind, entityId);
+    List<String> usersIds = (ArrayList) (entity.getProperty(propertyName));
+    return (usersIds != null) && usersIds.contains(userId);
+  }
+
+  /**
+   * Checks if the user is a member of the specified group.
+   *
+   * @param userId The id of the user.
+   * @param groupId The id of the group.
+   * @return True if the user is a member of the group.
+   */
+  public boolean isMemberOfGroup(String userId, long groupId) {
+    return isPartOfEntity(userId, groupId, GroupEntity.KIND.getLabel(),
+      GroupEntity.STUDENTS_PROPERTY.getLabel());
+  }
+
+  /**
+   * Checks if the user is an attendee of the specified event.
+   *
+   * @param userId The id of the user.
+   * @param eventId The id of the event.
+   * @return True if the user is an attendee of the event.
+   */
+  public boolean isAttendeeOfEvent(String userId, long eventId) {
+    return isPartOfEntity(userId, eventId, EventEntity.KIND.getLabel(),
+      EventEntity.ATTENDEES_PROPERTY.getLabel());
+  }
 }

--- a/src/main/java/com/google/lecturechat/data/Event.java
+++ b/src/main/java/com/google/lecturechat/data/Event.java
@@ -30,10 +30,10 @@ public final class Event {
   private final long endTime;
 
   private final String creator;
-  private final List<Long> attendees;
+  private final List<String> attendees;
 
   public Event(
-      long id, String title, long startTime, long endTime, String creator, List<Long> attendees) {
+      long id, String title, long startTime, long endTime, String creator, List<String> attendees) {
     this.id = id;
     this.title = title;
     this.startTime = startTime;
@@ -62,7 +62,7 @@ public final class Event {
     return creator;
   }
 
-  public List<Long> getAttendees() {
+  public List<String> getAttendees() {
     return attendees;
   }
 
@@ -73,7 +73,7 @@ public final class Event {
       long startTime = (long) (eventEntity.getProperty(EventEntity.START_PROPERTY.getLabel()));
       long endTime = (long) (eventEntity.getProperty(EventEntity.END_PROPERTY.getLabel()));
       String creator = (String) (eventEntity.getProperty(EventEntity.CREATOR_PROPERTY.getLabel()));
-      List<Long> attendees =
+      List<String> attendees =
           (ArrayList) (eventEntity.getProperty(EventEntity.ATTENDEES_PROPERTY.getLabel()));
       return new Event(id, title, startTime, endTime, creator, attendees);
     } else {

--- a/src/main/java/com/google/lecturechat/data/Group.java
+++ b/src/main/java/com/google/lecturechat/data/Group.java
@@ -26,11 +26,11 @@ public final class Group {
   private final String university;
   private final String degree;
   private final int year;
-  private final List<Long> students;
+  private final List<String> students;
   private final List<Long> events;
 
   public Group(
-      long id, String university, String degree, int year, List<Long> students, List<Long> events) {
+      long id, String university, String degree, int year, List<String> students, List<Long> events) {
     this.id = id;
     this.university = university;
     this.degree = degree;
@@ -55,7 +55,7 @@ public final class Group {
     return year;
   }
 
-  public List<Long> getStudents() {
+  public List<String> getStudents() {
     return students;
   }
 
@@ -71,7 +71,7 @@ public final class Group {
       String degree = (String) (groupEntity.getProperty(GroupEntity.DEGREE_PROPERTY.getLabel()));
       Long longYear = (Long) (groupEntity.getProperty(GroupEntity.YEAR_PROPERTY.getLabel()));
       int year = longYear.intValue();
-      List<Long> students =
+      List<String> students =
           (ArrayList) (groupEntity.getProperty(GroupEntity.STUDENTS_PROPERTY.getLabel()));
       List<Long> events =
           (ArrayList) (groupEntity.getProperty(GroupEntity.EVENTS_PROPERTY.getLabel()));

--- a/src/main/java/com/google/lecturechat/data/Group.java
+++ b/src/main/java/com/google/lecturechat/data/Group.java
@@ -30,7 +30,12 @@ public final class Group {
   private final List<Long> events;
 
   public Group(
-      long id, String university, String degree, int year, List<String> students, List<Long> events) {
+      long id,
+      String university,
+      String degree,
+      int year,
+      List<String> students,
+      List<Long> events) {
     this.id = id;
     this.university = university;
     this.degree = degree;

--- a/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/GroupEventsServlet.java
@@ -55,6 +55,10 @@ public class GroupEventsServlet extends HttpServlet {
 
     try {
       long groupId = Long.parseLong(request.getParameter(GROUP_ID_PARAMETER));
+      if (!datastore.isMemberOfGroup(userId.get(), groupId)) {
+        return;
+      }
+
       List<Event> events = datastore.getAllNotJoinedEventsFromGroup(groupId, userId.get());
       response.setContentType("application/json;");
       response.setCharacterEncoding("UTF-8");
@@ -75,6 +79,10 @@ public class GroupEventsServlet extends HttpServlet {
 
     try {
       long groupId = Long.parseLong(request.getParameter(GROUP_ID_PARAMETER));
+      if (!datastore.isMemberOfGroup(userId.get(), groupId)) {
+        return;
+      }
+
       String title = (String) request.getParameter(TITLE_PARAMETER);
       long start = Long.parseLong(request.getParameter(START_DATE_PARAMETER));
       long end = Long.parseLong(request.getParameter(END_DATE_PARAMETER));

--- a/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/JoinedEventsServlet.java
@@ -55,11 +55,15 @@ public class JoinedEventsServlet extends HttpServlet {
     }
 
     List<Event> events;
-    String groupId = request.getParameter(GROUP_ID_PARAMETER);
+    String groupIdString = request.getParameter(GROUP_ID_PARAMETER);
 
     try {
-      if (groupId != null) {
-        events = datastore.getAllJoinedEventsFromGroup(Long.parseLong(groupId), userId.get());
+      if (groupIdString != null) {
+        long groupId = Long.parseLong(groupIdString);
+        if (!datastore.isMemberOfGroup(userId.get(), groupId)) {
+          return;
+        }
+        events = datastore.getAllJoinedEventsFromGroup(groupId, userId.get());
       } else {
         String beginningDate = request.getParameter(BEGINNING_DATE_PARAMETER);
         String endingDate = request.getParameter(ENDING_DATE_PARAMETER);


### PR DESCRIPTION
**We didn't include yet any verification** of the fact that **the user** that wants to modify or retrieve the list of events of a group **is actually a member of that group**. This pull requests introduces some helpful functions that can be used to **restrict the access only to the members** of a group.

The Group and the Event classes have been updated to store the user IDs as strings.

