### PR TITLE
Message deletion cron job

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+- description: "delete messages older than 24 hours"
+  url: /delete-messages
+  schedule: every day 00:00

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -476,7 +476,7 @@ public class DatastoreAccess {
    * @param hours The length of the timeframe where messages should be kept in hours.
    */
   public void deleteMessagesOlderThan(int hours) {
-    ZonedDateTime currentTime = LocalDateTime.now().atZone(ZoneId.systemDefault());
+    ZonedDateTime currentTime = LocalDateTime.now().atZone(ZoneId.of("UTC"));
     long timeFrameLimit = currentTime.minusHours(hours).toInstant().toEpochMilli();
 
     Query query = new Query(MessageEntity.KIND.getLabel());

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -34,6 +34,9 @@ import com.google.lecturechat.data.constants.EventEntity;
 import com.google.lecturechat.data.constants.GroupEntity;
 import com.google.lecturechat.data.constants.MessageEntity;
 import com.google.lecturechat.data.constants.UserEntity;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -466,4 +469,28 @@ public class DatastoreAccess {
     messageEntity.setProperty(MessageEntity.EVENT_PROPERTY.getLabel(), eventId);
     datastore.put(messageEntity);
   }
+
+  /**
+   * Deletes all messages older than a certain timeframe.
+   *
+   * @param hours The length of the timeframe where messages should be kept in hours.
+   */
+  public void deleteMessagesOlderThan(int hours) {
+    ZonedDateTime currentTime = LocalDateTime.now().atZone(ZoneId.systemDefault());
+    long timeFrameLimit = currentTime.minusHours(hours).toInstant().toEpochMilli();
+
+    Query query = new Query(MessageEntity.KIND.getLabel());
+    query.setFilter(
+        new FilterPredicate(
+            MessageEntity.TIMESTAMP_PROPERTY.getLabel(), FilterOperator.LESS_THAN, timeFrameLimit));
+
+    PreparedQuery results = datastore.prepare(query);
+    List<Key> messagesToBeDeleted = new ArrayList<>();
+    for (Entity entity : results.asIterable()) {
+      messagesToBeDeleted.add(entity.getKey());
+    }
+    
+    datastore.delete(messagesToBeDeleted);
+  }
 }
+

--- a/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
+++ b/src/main/java/com/google/lecturechat/data/DatastoreAccess.java
@@ -35,8 +35,8 @@ import com.google.lecturechat.data.constants.GroupEntity;
 import com.google.lecturechat.data.constants.MessageEntity;
 import com.google.lecturechat.data.constants.UserEntity;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -489,8 +489,6 @@ public class DatastoreAccess {
     for (Entity entity : results.asIterable()) {
       messagesToBeDeleted.add(entity.getKey());
     }
-    
     datastore.delete(messagesToBeDeleted);
   }
 }
-

--- a/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/delete-messages")
 public class DeleteMessagesCronServlet extends HttpServlet {
 
-  // Delete all messages older than 24 hours.
   private static final int TIMEFRAME_MESSAGES_TO_KEEP = 24;
   private static DatastoreAccess datastore;
 

--- a/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
@@ -21,8 +21,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** 
- * Servlet for deleting all chat messages before a certain time. Only to be called by a cron job. 
+/**
+ * Servlet for deleting all chat messages before a certain time. Only to be called by a cron job.
  */
 @WebServlet("/delete-messages")
 public class DeleteMessagesCronServlet extends HttpServlet {
@@ -44,7 +44,6 @@ public class DeleteMessagesCronServlet extends HttpServlet {
     }
     datastore.deleteMessagesOlderThan(TIMEFRAME_MESSAGES_TO_KEEP);
   }
-
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
@@ -15,16 +15,15 @@
 package com.google.lecturechat.servlets;
 
 import com.google.lecturechat.data.DatastoreAccess;
-import com.google.lecturechat.data.Message;
 import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet for deleting all chat messages before a certain time. Only to be called by a cron job. */
+/** 
+ * Servlet for deleting all chat messages before a certain time. Only to be called by a cron job. 
+ */
 @WebServlet("/delete-messages")
 public class DeleteMessagesCronServlet extends HttpServlet {
 

--- a/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.lecturechat.servlets;
+
+import com.google.lecturechat.data.DatastoreAccess;
+import com.google.lecturechat.data.Message;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet for deleting all chat messages before a certain time. Only to be called by a cron job. */
+@WebServlet("/delete-messages")
+public class MessageServlet extends HttpServlet {
+
+  private static final int TIMEFRAME_MESSAGES_TO_KEEP = 24;
+  private static DatastoreAccess datastore;
+
+  @Override
+  public void init() {
+    datastore = DatastoreAccess.getDatastoreAccess();
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String cronHeader = request.getHeader("X-Appengine-Cron");
+    if (cronHeader == null || !cronHeader.equals("true")) {
+      return;
+    }
+    datastore.deleteMessagesOlderThan(TIMEFRAME_MESSAGES_TO_KEEP);
+  }
+
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    doGet(request, response);
+  }
+}

--- a/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
+++ b/src/main/java/com/google/lecturechat/servlets/DeleteMessagesCronServlet.java
@@ -26,8 +26,9 @@ import javax.servlet.http.HttpServletResponse;
 
 /** Servlet for deleting all chat messages before a certain time. Only to be called by a cron job. */
 @WebServlet("/delete-messages")
-public class MessageServlet extends HttpServlet {
+public class DeleteMessagesCronServlet extends HttpServlet {
 
+  // Delete all messages older than 24 hours.
   private static final int TIMEFRAME_MESSAGES_TO_KEEP = 24;
   private static DatastoreAccess datastore;
 

--- a/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
+++ b/src/test/java/com/google/lecturechat/DatastoreAccessTest.java
@@ -51,6 +51,7 @@ public final class DatastoreAccessTest {
   private final String USER_ID = "User Id A";
   private final String USER_NAME = "User Name A";
   private final String MESSAGE_CONTENT = "Message A";
+  private final long EVENT_ID = 123L;
 
   // Constants since we don't have access to the constants files here.
   private final String groupEntityLabel = "Group";
@@ -176,12 +177,11 @@ public final class DatastoreAccessTest {
 
   @Test
   public void addAndRetrieveCorrectNumberOfMessages() {
-    long eventId = 123L;
-    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
-    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
-    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
 
-    List<Message> messages = datastore.getMessagesFromEvent(eventId, 20);
+    List<Message> messages = datastore.getMessagesFromEvent(EVENT_ID, 20);
 
     assertEquals(3, service.prepare(new Query(messageEntityLabel)).countEntities());
     assertEquals(3, messages.size());
@@ -189,12 +189,33 @@ public final class DatastoreAccessTest {
 
   @Test
   public void addAndRetrieveCorrectNumberOfMessagesWithLimit() {
-    long eventId = 123L;
-    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
-    datastore.addMessage(eventId, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
 
-    List<Message> messages = datastore.getMessagesFromEvent(eventId, 1);
+    List<Message> messages = datastore.getMessagesFromEvent(EVENT_ID, 1);
 
     assertEquals(1, messages.size());
+  }
+
+  @Test
+  public void deleteOldMessagesDeletesAllMessagesWhenTimeframeHoursAreZero() {
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+
+    datastore.deleteMessagesOlderThan(0);
+
+    assertEquals(0, service.prepare(new Query(messageEntityLabel)).countEntities());
+  }
+
+  @Test
+  public void deleteOldMessagesDoesntDeleteMessagesNewerThanTimeframe() {
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+    datastore.addMessage(EVENT_ID, MESSAGE_CONTENT, USER_NAME);
+
+    datastore.deleteMessagesOlderThan(24);
+
+    assertEquals(3, service.prepare(new Query(messageEntityLabel)).countEntities());
   }
 }


### PR DESCRIPTION
Closes #24 

This update adds a cron job that deletes messages that are older than 24 hours daily at midnight:

- `DatastoreAccess` now has a method that deletes all messages that are older than a specified time intervall
- `DeleteMessagesCronServlet` is an endpoint that can only be called by the cron job (verified using a http request header)
- `cron.yaml` specifies the cron job

Current Status (16/09/20): The method for deleting messages has been unit tested, and the servlet has been manually tested, but we need to wait to check whether the job works as expected. 

Update (17/09/20): Has now successfully run.